### PR TITLE
Extend utilities and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Lint
+        run: |
+          black --check .
+          flake8
+      - name: Test
+        run: pytest -q
+

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ This repository is a playful collaboration between Costas and ChatGPT. We mix co
 ```
 src/            # Python package source
   gpt_fusion/   # package implementation
-    core.py     # initial greeting helper
+    core.py     # greeting helper
+    utils.py    # math helpers and chat history container
 
 tests/          # pytest-based unit tests
 
-docs/           # documentation (future)
+docs/           # documentation with examples
  data/           # sample data (future)
 ```
 
@@ -31,3 +32,7 @@ docs/           # documentation (future)
 5. **Contributions**: Please open issues and pull requests via GitHub. Keep commits clear and focused.
 
 Enjoy fusing ideas with code!
+
+## Sample apps
+
+Check out `auth-ui-kit/` for a simple web login example and `unity-prototype/` for a basic Unity setup.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,34 @@
 # Documentation
 
-This folder will contain project documentation as the project grows.
+This project demonstrates small utilities for blending human and AI workflows.
+
+## Usage examples
+
+### Greeting helper
+
+```python
+from gpt_fusion import greet
+
+print(greet("World"))
+```
+
+### Math utilities
+
+```python
+from gpt_fusion import add_numbers, multiply_numbers
+
+add_numbers(2, 3)       # -> 5
+multiply_numbers(4, 2)  # -> 8
+```
+
+### Chat history
+
+```python
+from gpt_fusion import ChatHistory
+
+history = ChatHistory(messages=[])
+history.add_message("Hello")
+history.add_message("How are you?")
+print(history.last_message())  # -> "How are you?"
+```
+

--- a/src/gpt_fusion/__init__.py
+++ b/src/gpt_fusion/__init__.py
@@ -1,0 +1,11 @@
+"""Top-level package for gpt-fusion."""
+
+from .core import greet
+from .utils import ChatHistory, add_numbers, multiply_numbers
+
+__all__ = [
+    "greet",
+    "ChatHistory",
+    "add_numbers",
+    "multiply_numbers",
+]

--- a/src/gpt_fusion/utils.py
+++ b/src/gpt_fusion/utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def add_numbers(a: float, b: float) -> float:
+    """Return the sum of *a* and *b*."""
+    return a + b
+
+
+def multiply_numbers(a: float, b: float) -> float:
+    """Return the product of *a* and *b*."""
+    return a * b
+
+
+@dataclass
+class ChatHistory:
+    """Simple container for tracking conversation messages."""
+
+    messages: list[str]
+
+    def add_message(self, text: str) -> None:
+        """Append *text* to the history."""
+        self.messages.append(text)
+
+    def last_message(self) -> str | None:
+        """Return the most recent message or ``None`` if empty."""
+        return self.messages[-1] if self.messages else None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+from gpt_fusion.utils import add_numbers, multiply_numbers, ChatHistory
+
+
+def test_add_numbers():
+    assert add_numbers(2, 3) == 5
+
+
+def test_multiply_numbers():
+    assert multiply_numbers(2, 4) == 8
+
+
+def test_chat_history():
+    history = ChatHistory(messages=[])
+    history.add_message("hello")
+    history.add_message("world")
+    assert history.last_message() == "world"


### PR DESCRIPTION
## Summary
- add simple utilities module with math helpers and ChatHistory
- expose new functions in `gpt_fusion` package
- document usage examples in docs
- update project README with new layout and sample apps
- add GitHub Actions workflow for lint and test
- expand unit tests for new utilities

## Testing
- `black src tests -q`
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687135579cf883218aac442bae859a2b