### PR TITLE
Add simple GitHub Pages site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-cayman
+title: GPT Fusion
+description: Human charm meets algorithmic arm

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+---
+layout: default
+title: GPT Fusion Playground
+---
+
+# GPT Fusion Playground
+
+**Human charm meets algorithmic arm**
+
+Welcome to **GPT Fusion**, a small playground for blending human creativity with AI tooling. Explore the projects below to see what we're experimenting with.
+
+## Projects
+
+- **Python utilities** – reusable helpers for greetings, math and simple CSV analysis. [Read the docs](README.md).
+- **Auth UI Kit** – Tailwind CSS login form using Firebase. [View the demo](../auth-ui-kit/index.html).
+- **Unity prototype** – a basic Unity setup for AI experiments. [Check the repo](../unity-prototype/).
+- **Tutorial** – learn how to load sample data and compute averages. [Follow the tutorial](tutorial.md).
+
+Enjoy fusing ideas with code!


### PR DESCRIPTION
## Summary
- create `_config.yml` with a minimal Jekyll theme
- add an `index.md` landing page under `docs/`

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68714973eae88321a91d18100868d37a