### PR TITLE
Improve docs and remove demo images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ htmlcov/
 
 # Misc
 *.log
+docs/assets/*.png

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,22 @@
 
 This project demonstrates small utilities for blending human and AI workflows.
 
+## Project overview
+
+The repository contains a few loosely coupled pieces that can be mixed and
+matched:
+
+- **Python utilities** (`gpt_fusion` package) – greeting helpers, math functions
+  and a tiny CSV reader used throughout the docs and tests.
+- **Auth UI Kit** – a Tailwind‑styled login form built with Firebase. It can be
+  wired up to the Python utilities for quick experiments.
+- **Unity prototype** – a starter Unity project showcasing basic player control
+  scripts. Useful for exploring AI behaviour in a 3D environment.
+- **Documentation** – these markdown files, rendered using Jekyll.
+
+Each component is small on its own, but together they highlight different ways
+to fuse code written by humans and AI tools.
+
 ## Usage examples
 
 ### Greeting helper
@@ -31,6 +47,17 @@ history.add_message("Hello")
 history.add_message("How are you?")
 print(history.last_message())  # -> "How are you?"
 ```
+
+## Quickstart
+
+If you just want to see everything working, follow these steps and then head
+back to the [main README](../README.md) for more detail:
+
+1. Clone this repository.
+2. Run `pytest` from the project root to ensure the utilities work as expected.
+3. Serve the login demo with `python -m http.server --directory auth-ui-kit` and
+   open `http://localhost:8000` in your browser.
+4. Open the `unity-prototype` folder in Unity to explore the 3D example.
 
 ## Further reading
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,16 @@ title: GPT Fusion Playground
 
 Welcome to **GPT Fusion**, a small playground for blending human creativity with AI tooling. Explore the projects below to see what we're experimenting with.
 
+## Quickstart
+
+New to the repo? See the [main README](../README.md) for setup details. In
+short, clone the project, run `pytest` to verify the Python utilities and then
+open the demos described below.
+
+These small examples feed into one another. The Python helpers can power the
+login form or provide data for the Unity prototype. Throughout the docs you'll
+see how tests and tutorials tie the components together.
+
 ## Projects
 
 ### Python utilities
@@ -19,9 +29,13 @@ Reusable helpers for greetings, math and simple CSV analysis. [Read the docs](RE
 
 Tailwind CSS login form using Firebase. [View the demo](../auth-ui-kit/index.html).
 
+![Auth UI screenshot](assets/auth-ui-screenshot.png)
+
 ### Unity prototype
 
 A basic Unity setup for AI experiments. [Check the repo](../unity-prototype/).
+
+![Unity demo](assets/unity-demo.png)
 
 ### Tutorial
 

--- a/src/gpt_fusion/__init__.py
+++ b/src/gpt_fusion/__init__.py
@@ -2,8 +2,13 @@
 
 from .analysis import average_from_csv, load_numbers_from_csv
 from .core import greet
-from .utils import (ChatHistory, add_numbers, divide_numbers, multiply_numbers,
-                    subtract_numbers)
+from .utils import (
+    ChatHistory,
+    add_numbers,
+    divide_numbers,
+    multiply_numbers,
+    subtract_numbers,
+)
 
 __all__ = [
     "greet",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,12 @@
 import pytest
 
-from gpt_fusion.utils import (ChatHistory, add_numbers, divide_numbers,
-                              multiply_numbers, subtract_numbers)
+from gpt_fusion.utils import (
+    ChatHistory,
+    add_numbers,
+    divide_numbers,
+    multiply_numbers,
+    subtract_numbers,
+)
 
 
 def test_add_numbers():


### PR DESCRIPTION
## Summary
- expand docs with project overview and quickstart
- add screenshot placeholders for the auth UI and Unity examples
- remove demo images from version control and ignore the asset files

## Testing
- `black . --check`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687156a6cef08321867bb903f10bb7d7