### PR TITLE
Fix CSV reading encoding

### DIFF
--- a/src/gpt_fusion/analysis.py
+++ b/src/gpt_fusion/analysis.py
@@ -7,7 +7,7 @@ from statistics import mean
 
 def load_numbers_from_csv(path: str | Path) -> list[float]:
     """Load numbers from a CSV file with a ``value`` column."""
-    with open(path, newline="") as f:
+    with open(path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         return [float(row["value"]) for row in reader]
 


### PR DESCRIPTION
## Summary
- ensure `load_numbers_from_csv` opens files using UTF-8

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68715e3618bc8321b0eb8d99d69241d5