### PR TITLE
Add CSV median and history clearing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,8 @@ history = ChatHistory(messages=[])
 history.add_message("Hello")
 history.add_message("How are you?")
 print(history.last_message())  # -> "How are you?"
+history.clear()
+print(history.messages)  # -> []
 ```
 
 ## Quickstart

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -5,10 +5,11 @@ value using ``gpt_fusion`` utilities.
 
 ```python
 from pathlib import Path
-from gpt_fusion import load_numbers_from_csv, average_from_csv
+from gpt_fusion import load_numbers_from_csv, average_from_csv, median_from_csv
 
 csv_path = Path("../data/numbers.csv")
 values = load_numbers_from_csv(csv_path)
 print(f"Loaded values: {values}")
 print(f"Average: {average_from_csv(csv_path)}")
+print(f"Median: {median_from_csv(csv_path)}")
 ```

--- a/src/gpt_fusion/__init__.py
+++ b/src/gpt_fusion/__init__.py
@@ -1,6 +1,6 @@
 """Top-level package for gpt-fusion."""
 
-from .analysis import average_from_csv, load_numbers_from_csv
+from .analysis import average_from_csv, load_numbers_from_csv, median_from_csv
 from .core import greet
 from .utils import (
     ChatHistory,
@@ -19,4 +19,5 @@ __all__ = [
     "divide_numbers",
     "load_numbers_from_csv",
     "average_from_csv",
+    "median_from_csv",
 ]

--- a/src/gpt_fusion/analysis.py
+++ b/src/gpt_fusion/analysis.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import csv
 from pathlib import Path
-from statistics import mean
+from statistics import mean, median
 
 
 def load_numbers_from_csv(path: str | Path) -> list[float]:
@@ -16,3 +16,9 @@ def average_from_csv(path: str | Path) -> float:
     """Return the average of the ``value`` column in *path*."""
     values = load_numbers_from_csv(path)
     return mean(values) if values else 0.0
+
+
+def median_from_csv(path: str | Path) -> float:
+    """Return the median of the ``value`` column in *path*."""
+    values = load_numbers_from_csv(path)
+    return median(values) if values else 0.0

--- a/src/gpt_fusion/utils.py
+++ b/src/gpt_fusion/utils.py
@@ -38,3 +38,7 @@ class ChatHistory:
     def last_message(self) -> str | None:
         """Return the most recent message or ``None`` if empty."""
         return self.messages[-1] if self.messages else None
+
+    def clear(self) -> None:
+        """Remove all messages from the history."""
+        self.messages.clear()

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from gpt_fusion.analysis import average_from_csv, load_numbers_from_csv
+from gpt_fusion.analysis import (
+    average_from_csv,
+    load_numbers_from_csv,
+    median_from_csv,
+)
 
 DATA_PATH = Path(__file__).resolve().parents[1] / "data" / "numbers.csv"
 
@@ -12,3 +16,7 @@ def test_load_numbers_from_csv():
 
 def test_average_from_csv():
     assert average_from_csv(DATA_PATH) == 3.0
+
+
+def test_median_from_csv():
+    assert median_from_csv(DATA_PATH) == 3.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,6 +37,13 @@ def test_chat_history():
     assert history.last_message() == "world"
 
 
+def test_clear_chat_history():
+    history = ChatHistory(messages=["hello", "world"])
+    history.clear()
+    assert history.messages == []
+    assert history.last_message() is None
+
+
 def test_last_message_empty_returns_none():
     history = ChatHistory(messages=[])
     assert history.last_message() is None


### PR DESCRIPTION
## Summary
- compute the median value from a CSV file
- expose the new helper and document it in the tutorial
- allow `ChatHistory` objects to be cleared and show usage in docs
- add tests for new functionality

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872727fb44883219b9d3785d7eca221