### PR TITLE
Add web scraper utility

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -12,3 +12,14 @@ values = load_numbers_from_csv(csv_path)
 print(f"Loaded values: {values}")
 print(f"Average: {average_from_csv(csv_path)}")
 ```
+
+### Web scraping
+
+Use the ``scrape`` helper to pull text from any page using a CSS selector:
+
+```python
+from gpt_fusion import scrape
+
+titles = scrape("https://example.com", "h1")
+print(titles)
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,5 @@ black
 flake8
 pytest
 pre-commit
+requests
+beautifulsoup4

--- a/src/gpt_fusion/__init__.py
+++ b/src/gpt_fusion/__init__.py
@@ -2,6 +2,7 @@
 
 from .analysis import average_from_csv, load_numbers_from_csv
 from .core import greet
+from .web_scraper import scrape
 from .utils import (
     ChatHistory,
     add_numbers,
@@ -19,4 +20,5 @@ __all__ = [
     "divide_numbers",
     "load_numbers_from_csv",
     "average_from_csv",
+    "scrape",
 ]

--- a/src/gpt_fusion/web_scraper.py
+++ b/src/gpt_fusion/web_scraper.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def scrape(url: str, css_selector: str) -> list[str]:
+    """Return text content of elements matching *css_selector* from *url*."""
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+    elements = soup.select(css_selector)
+    return [element.get_text(strip=True) for element in elements]

--- a/tests/test_web_scraper.py
+++ b/tests/test_web_scraper.py
@@ -1,0 +1,22 @@
+from unittest.mock import Mock, patch
+
+from gpt_fusion.web_scraper import scrape
+
+
+def test_scrape_parses_text():
+    html = (
+        "<html><body>"
+        "<p class='msg'>Hello</p>"
+        "<p class='msg'>World</p>"
+        "</body></html>"
+    )
+
+    mock_response = Mock()
+    mock_response.text = html
+    mock_response.raise_for_status = Mock()
+
+    with patch("requests.get", return_value=mock_response) as mock_get:
+        result = scrape("http://example.com", "p.msg")
+        mock_get.assert_called_once_with("http://example.com", timeout=10)
+
+    assert result == ["Hello", "World"]


### PR DESCRIPTION
## Summary
- add `scrape` helper using requests and BeautifulSoup
- expose `scrape` in package init
- document scraping example in tutorial
- add tests for the new helper
- include requests and beautifulsoup4 in dev requirements

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687275d29fe88321840e087386e0ce40