### PR TITLE
Ensure external links open in new tab

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,3 +66,5 @@ back to the [main README](https://github.com/costasford/gpt-fusion#readme) for m
 See [tutorial.md](tutorial.md) for a walkthrough on loading the sample dataset
 and computing averages.
 
+<script src="assets/js/external-links.js"></script>
+

--- a/docs/assets/js/external-links.js
+++ b/docs/assets/js/external-links.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const anchors = document.querySelectorAll('a[href]');
+  anchors.forEach(a => {
+    const url = new URL(a.getAttribute('href'), window.location.href);
+    if (url.host && url.host !== window.location.host) {
+      a.setAttribute('target', '_blank');
+      if (!a.getAttribute('rel')) {
+        a.setAttribute('rel', 'noopener');
+      }
+    }
+  });
+});

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,3 +49,5 @@ A basic Unity setup for AI experiments. [Check the repo](https://github.com/cost
 Learn how to load sample data and compute averages. [Follow the tutorial](tutorial.md).
 
 Enjoy fusing ideas with code!
+
+<script src="assets/js/external-links.js"></script>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -24,3 +24,5 @@ from gpt_fusion import scrape
 titles = scrape("https://example.com", "h1")
 print(titles)
 ```
+
+<script src="assets/js/external-links.js"></script>


### PR DESCRIPTION
## Summary
- add JS helper to force links to open in a new tab when they point off-site
- load that script across the documentation pages

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68728dbe57d08321b52ac8824df0072e