### PR TITLE
Fix JS for external links

### DIFF
--- a/docs/assets/js/external-links.js
+++ b/docs/assets/js/external-links.js
@@ -1,18 +1,17 @@
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('a[href]').forEach((a) => {
-    if (!a.getAttribute('target')) {
-      a.setAttribute('target', '_blank');
-    }
-    const rel = a.getAttribute('rel');
-    if (!rel || !rel.includes('noopener')) {
-      a.setAttribute('rel', (rel ? rel + ' ' : '') + 'noopener');
   const anchors = document.querySelectorAll('a[href]');
-  anchors.forEach(a => {
+
+  anchors.forEach((a) => {
     const url = new URL(a.getAttribute('href'), window.location.href);
-    if (url.host && url.host !== window.location.host) {
-      a.setAttribute('target', '_blank');
-      if (!a.getAttribute('rel')) {
-        a.setAttribute('rel', 'noopener');
+
+    if (url.origin !== window.location.origin) {
+      if (!a.hasAttribute('target')) {
+        a.setAttribute('target', '_blank');
+      }
+
+      const rel = a.getAttribute('rel') || '';
+      if (!rel.includes('noopener')) {
+        a.setAttribute('rel', rel ? `${rel} noopener` : 'noopener');
       }
     }
   });


### PR DESCRIPTION
## Summary
- clean up the external links helper script
- respect pre-defined targets when opening external links

## Testing
- `black . --check`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872913ad36c8321a106d514efa25db8