### PR TITLE
Add Twitter bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ data/           # sample data
 ## Development workflow
 
 1. **Environment**: Use Python 3.8+.
-2. **Dependencies**: The project relies only on the Python standard library, so there are no runtime packages to install.
+2. **Dependencies**: The core library uses only the Python standard library. The optional Twitter bot requires [tweepy](https://www.tweepy.org/).
 3. **Style**: Format code with [black](https://github.com/psf/black) and lint with [flake8](https://github.com/PyCQA/flake8). A [pre-commit](https://pre-commit.com) hook runs these automatically.
 4. **Tests**: Run `pytest` before submitting changes.
 5. **Hooks**: After installing dependencies, run `pre-commit install` so formatting and linting run on each commit.
@@ -40,7 +40,7 @@ Enjoy fusing ideas with code!
 
 ## Sample apps
 
-Check out `auth-ui-kit/` for a simple web login example and `unity-prototype/` for a basic Unity setup.
+Check out `auth-ui-kit/` for a simple web login example, `twitter_bot.py` for posting project updates to Twitter, and `unity-prototype/` for a basic Unity setup.
 
 ## Data
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest
 pre-commit
 requests
 beautifulsoup4
+tweepy

--- a/src/gpt_fusion/__init__.py
+++ b/src/gpt_fusion/__init__.py
@@ -3,6 +3,7 @@
 from .analysis import average_from_csv, load_numbers_from_csv, median_from_csv
 from .core import greet
 from .web_scraper import scrape
+from .twitter_bot import TwitterBot
 from .utils import (
     ChatHistory,
     add_numbers,
@@ -22,4 +23,5 @@ __all__ = [
     "average_from_csv",
     "scrape",
     "median_from_csv",
+    "TwitterBot",
 ]

--- a/src/gpt_fusion/twitter_bot.py
+++ b/src/gpt_fusion/twitter_bot.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Simple Twitter bot utilities."""
+
+import os
+from dataclasses import dataclass
+
+import tweepy
+
+
+@dataclass
+class TwitterBot:
+    """A small wrapper around Tweepy for posting tweets."""
+
+    api_key: str | None = None
+    api_secret: str | None = None
+    access_token: str | None = None
+    access_secret: str | None = None
+
+    def __post_init__(self) -> None:
+        self.api_key = self.api_key or os.getenv("TWITTER_API_KEY")
+        self.api_secret = self.api_secret or os.getenv("TWITTER_API_SECRET")
+        self.access_token = self.access_token or os.getenv(
+            "TWITTER_ACCESS_TOKEN"
+        )  # noqa: E501
+        self.access_secret = self.access_secret or os.getenv(
+            "TWITTER_ACCESS_SECRET"
+        )  # noqa: E501
+
+        if not all(
+            [
+                self.api_key,
+                self.api_secret,
+                self.access_token,
+                self.access_secret,
+            ]
+        ):
+            raise ValueError("Twitter credentials are not fully specified")
+
+        auth = tweepy.OAuth1UserHandler(
+            self.api_key,
+            self.api_secret,
+            self.access_token,
+            self.access_secret,
+        )
+        self.client = tweepy.API(auth)
+
+    def post_tweet(self, message: str) -> None:
+        """Post *message* to Twitter."""
+        self.client.update_status(message)

--- a/tests/test_twitter_bot.py
+++ b/tests/test_twitter_bot.py
@@ -1,0 +1,14 @@
+from unittest.mock import patch
+
+from gpt_fusion.twitter_bot import TwitterBot
+
+
+def test_post_tweet_invokes_tweepy():
+    with patch("tweepy.OAuth1UserHandler") as mock_handler, patch(
+        "tweepy.API"
+    ) as mock_api:
+        api_instance = mock_api.return_value
+        bot = TwitterBot("k", "s", "t", "c")
+        bot.post_tweet("hello")
+        api_instance.update_status.assert_called_once_with("hello")
+        mock_handler.assert_called_once()


### PR DESCRIPTION
## Summary
- introduce `TwitterBot` class for posting tweets
- export `TwitterBot` from package
- add `tweepy` dev dependency
- document the Twitter bot in README
- provide unit tests for the new module

## Testing
- `black src/gpt_fusion/twitter_bot.py tests/test_twitter_bot.py`
- `flake8 && echo OK`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872927c20ec832196792b411e6e1e7e