### PR TITLE
Add anchor links to docs site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,3 +68,4 @@ and computing averages.
 
 <script src="assets/js/external-links.js"></script>
 
+<script src="assets/js/anchor-links.js"></script>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -6,3 +6,19 @@ $header-bg-color-secondary: #cf6c0a;
 $section-headings-color: #ec7d0b;
 
 @import "{{ site.theme }}";
+
+.anchor-link {
+  margin-left: 0.25rem;
+  font-size: 0.8em;
+  text-decoration: none;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+h2:hover .anchor-link,
+h3:hover .anchor-link,
+h4:hover .anchor-link,
+h5:hover .anchor-link,
+h6:hover .anchor-link {
+  opacity: 1;
+}

--- a/docs/assets/js/anchor-links.js
+++ b/docs/assets/js/anchor-links.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const headings = document.querySelectorAll('h2, h3, h4, h5, h6');
+  headings.forEach((h) => {
+    if (!h.id) {
+      const slug = h.textContent
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+      h.id = slug;
+    }
+
+    const link = document.createElement('a');
+    link.className = 'anchor-link';
+    link.href = `#${h.id}`;
+    link.textContent = '🔗';
+    h.appendChild(link);
+  });
+});

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,3 +51,4 @@ Learn how to load sample data and compute averages. [Follow the tutorial](tutori
 Enjoy fusing ideas with code!
 
 <script src="assets/js/external-links.js"></script>
+<script src="assets/js/anchor-links.js"></script>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -26,3 +26,4 @@ print(titles)
 ```
 
 <script src="assets/js/external-links.js"></script>
+<script src="assets/js/anchor-links.js"></script>


### PR DESCRIPTION
## Summary
- add JavaScript for heading anchor links
- update custom styles for anchor links
- include new script in all docs pages

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68729ec9763083219e6c97203614a727