### PR TITLE
Enhance login demo with remember-me option

### DIFF
--- a/auth-ui-kit/app.js
+++ b/auth-ui-kit/app.js
@@ -9,9 +9,24 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 
+// Pre-fill email if saved
+document.addEventListener("DOMContentLoaded", () => {
+  const savedEmail = localStorage.getItem("savedEmail");
+  if (savedEmail) {
+    document.getElementById("email").value = savedEmail;
+    document.getElementById("remember").checked = true;
+  }
+});
+
 document.getElementById("login").addEventListener("click", async () => {
   const email = document.getElementById("email").value;
   const password = document.getElementById("password").value;
+  const remember = document.getElementById("remember").checked;
+  if (remember) {
+    localStorage.setItem("savedEmail", email);
+  } else {
+    localStorage.removeItem("savedEmail");
+  }
   try {
     await signInWithEmailAndPassword(auth, email, password);
     document.getElementById("message").textContent = "Logged in!";

--- a/auth-ui-kit/index.html
+++ b/auth-ui-kit/index.html
@@ -13,9 +13,13 @@
   <div class="bg-white p-6 rounded shadow w-80">
     <h1 class="text-xl font-bold mb-4 text-center">Login</h1>
     <input id="email" class="border p-2 w-full mb-2" type="email" placeholder="Email" />
-    <input id="password" class="border p-2 w-full mb-4" type="password" placeholder="Password" />
+    <input id="password" class="border p-2 w-full mb-2" type="password" placeholder="Password" />
+    <label class="flex items-center mb-4 text-sm">
+      <input id="remember" type="checkbox" class="mr-2" /> Remember me
+    </label>
     <button id="login" class="bg-blue-500 text-white px-4 py-2 w-full rounded">Login</button>
     <p id="message" class="text-red-500 mt-2 text-center"></p>
+    <p class="text-center text-sm mt-2">Don't have an account? <a href="#" class="text-blue-500 underline">Sign up</a></p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expand login page with a Remember Me checkbox and signup link
- preload email from localStorage in the demo script

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68729ed223548321b4be8d5d50f4d006