### PR TITLE
Add signup and reset features

### DIFF
--- a/auth-ui-kit/app.js
+++ b/auth-ui-kit/app.js
@@ -1,5 +1,11 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js";
-import { getAuth, signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
+import {
+  getAuth,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  sendEmailVerification,
+  sendPasswordResetEmail,
+} from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
 
 const firebaseConfig = {
   apiKey: "YOUR_API_KEY",
@@ -8,6 +14,27 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+
+export function isValidEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function showMessage(id, msg) {
+  document.getElementById(id).textContent = msg;
+}
+
+async function withLoading(btnId, fn) {
+  const btn = document.getElementById(btnId);
+  const original = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = "Loading...";
+  try {
+    await fn();
+  } finally {
+    btn.disabled = false;
+    btn.textContent = original;
+  }
+}
 
 // Pre-fill email if saved
 document.addEventListener("DOMContentLoaded", () => {
@@ -27,10 +54,80 @@ document.getElementById("login").addEventListener("click", async () => {
   } else {
     localStorage.removeItem("savedEmail");
   }
-  try {
-    await signInWithEmailAndPassword(auth, email, password);
-    document.getElementById("message").textContent = "Logged in!";
-  } catch (err) {
-    document.getElementById("message").textContent = err.message;
+  if (!isValidEmail(email)) {
+    showMessage("message", "Invalid email format");
+    return;
   }
+  await withLoading("login", async () => {
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+      showMessage("message", "Logged in!");
+    } catch (err) {
+      showMessage("message", err.message);
+    }
+  });
+});
+
+// Show/Hide modals
+document.getElementById("show-signup").addEventListener("click", () => {
+  document.getElementById("signup-modal").classList.remove("hidden");
+});
+document.getElementById("signup-close").addEventListener("click", () => {
+  document.getElementById("signup-modal").classList.add("hidden");
+  showMessage("signup-message", "");
+});
+document.getElementById("forgot").addEventListener("click", () => {
+  document.getElementById("reset-modal").classList.remove("hidden");
+});
+document.getElementById("reset-close").addEventListener("click", () => {
+  document.getElementById("reset-modal").classList.add("hidden");
+  showMessage("reset-message", "");
+});
+
+// Sign up handler
+document.getElementById("signup-btn").addEventListener("click", async () => {
+  const email = document.getElementById("signup-email").value;
+  const password = document.getElementById("signup-password").value;
+  const confirm = document.getElementById("signup-confirm").value;
+  if (!isValidEmail(email)) {
+    showMessage("signup-message", "Invalid email format");
+    return;
+  }
+  if (password.length < 6) {
+    showMessage("signup-message", "Password must be at least 6 characters");
+    return;
+  }
+  if (password !== confirm) {
+    showMessage("signup-message", "Passwords do not match");
+    return;
+  }
+  await withLoading("signup-btn", async () => {
+    try {
+      const cred = await createUserWithEmailAndPassword(auth, email, password);
+      await sendEmailVerification(cred.user);
+      showMessage(
+        "signup-message",
+        "Account created. Check your email to verify."
+      );
+    } catch (err) {
+      showMessage("signup-message", err.message);
+    }
+  });
+});
+
+// Password reset handler
+document.getElementById("reset-btn").addEventListener("click", async () => {
+  const email = document.getElementById("reset-email").value;
+  if (!isValidEmail(email)) {
+    showMessage("reset-message", "Invalid email format");
+    return;
+  }
+  await withLoading("reset-btn", async () => {
+    try {
+      await sendPasswordResetEmail(auth, email);
+      showMessage("reset-message", "Reset email sent!");
+    } catch (err) {
+      showMessage("reset-message", err.message);
+    }
+  });
 });

--- a/auth-ui-kit/index.html
+++ b/auth-ui-kit/index.html
@@ -19,7 +19,71 @@
     </label>
     <button id="login" class="bg-blue-500 text-white px-4 py-2 w-full rounded">Login</button>
     <p id="message" class="text-red-500 mt-2 text-center"></p>
-    <p class="text-center text-sm mt-2">Don't have an account? <a href="#" class="text-blue-500 underline">Sign up</a></p>
+    <p class="text-center text-sm mt-2">
+      <a href="#" id="forgot" class="text-blue-500 underline">Forgot password?</a>
+    </p>
+    <p class="text-center text-sm mt-2">
+      Don't have an account?
+      <a href="#" id="show-signup" class="text-blue-500 underline">Sign up</a>
+    </p>
+  </div>
+
+  <!-- Sign up modal -->
+  <div
+    id="signup-modal"
+    class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center"
+  >
+    <div class="bg-white p-6 rounded shadow w-80">
+      <h1 class="text-xl font-bold mb-4 text-center">Sign Up</h1>
+      <input
+        id="signup-email"
+        class="border p-2 w-full mb-2"
+        type="email"
+        placeholder="Email"
+      />
+      <input
+        id="signup-password"
+        class="border p-2 w-full mb-2"
+        type="password"
+        placeholder="Password"
+      />
+      <input
+        id="signup-confirm"
+        class="border p-2 w-full mb-2"
+        type="password"
+        placeholder="Confirm Password"
+      />
+      <button id="signup-btn" class="bg-blue-500 text-white px-4 py-2 w-full rounded">
+        Sign Up
+      </button>
+      <p id="signup-message" class="text-red-500 mt-2 text-center"></p>
+      <button id="signup-close" class="text-sm text-blue-500 underline mt-2 w-full">
+        Cancel
+      </button>
+    </div>
+  </div>
+
+  <!-- Reset password modal -->
+  <div
+    id="reset-modal"
+    class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center"
+  >
+    <div class="bg-white p-6 rounded shadow w-80">
+      <h1 class="text-xl font-bold mb-4 text-center">Reset Password</h1>
+      <input
+        id="reset-email"
+        class="border p-2 w-full mb-2"
+        type="email"
+        placeholder="Email"
+      />
+      <button id="reset-btn" class="bg-blue-500 text-white px-4 py-2 w-full rounded">
+        Send reset email
+      </button>
+      <p id="reset-message" class="text-red-500 mt-2 text-center"></p>
+      <button id="reset-close" class="text-sm text-blue-500 underline mt-2 w-full">
+        Cancel
+      </button>
+    </div>
   </div>
 </body>
 </html>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,5 @@ pre-commit
 requests
 beautifulsoup4
 tweepy
+fastapi
+httpx<0.25

--- a/src/gpt_fusion/__init__.py
+++ b/src/gpt_fusion/__init__.py
@@ -3,6 +3,7 @@
 from .analysis import average_from_csv, load_numbers_from_csv, median_from_csv
 from .core import greet
 from .web_scraper import scrape
+from .backend import app as backend_app
 from .twitter_bot import TwitterBot
 from .utils import (
     ChatHistory,
@@ -24,4 +25,5 @@ __all__ = [
     "scrape",
     "median_from_csv",
     "TwitterBot",
+    "backend_app",
 ]

--- a/src/gpt_fusion/backend.py
+++ b/src/gpt_fusion/backend.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Profile(BaseModel):
+    uid: str
+    display_name: str
+
+
+@app.get("/profile/{uid}", response_model=Profile)
+def get_profile(uid: str):
+    return Profile(uid=uid, display_name=f"User {uid}")

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from gpt_fusion.backend import app
+
+client = TestClient(app)
+
+
+def test_get_profile():
+    response = client.get("/profile/test")
+    assert response.status_code == 200
+    assert response.json() == {"uid": "test", "display_name": "User test"}


### PR DESCRIPTION
## Summary
- extend `auth-ui-kit` with sign‑up and password reset modals
- add client-side validation and loading feedback in `app.js`
- provide a minimal FastAPI backend example and unit test
- update development requirements for FastAPI and httpx

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a3ecbdec83219e05a5c57adbac21