### PR TITLE
Add additional Unity sample scripts

### DIFF
--- a/unity-prototype/Assets/Scripts/AudioManager.cs
+++ b/unity-prototype/Assets/Scripts/AudioManager.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+/// <summary>
+/// Centralizes playing sound effects and music.
+/// </summary>
+public class AudioManager : MonoBehaviour
+{
+    public static AudioManager Instance { get; private set; }
+
+    public AudioSource musicSource;
+    public AudioSource sfxSource;
+
+    void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+        }
+        else
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+    }
+
+    public void PlaySFX(AudioClip clip)
+    {
+        sfxSource.PlayOneShot(clip);
+    }
+
+    public void PlayMusic(AudioClip clip)
+    {
+        if (musicSource.clip == clip)
+            return;
+
+        musicSource.clip = clip;
+        musicSource.Play();
+    }
+}

--- a/unity-prototype/Assets/Scripts/CameraController.cs
+++ b/unity-prototype/Assets/Scripts/CameraController.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+/// <summary>
+/// Smoothly follows a target with optional zoom and rotation controls.
+/// </summary>
+public class CameraController : MonoBehaviour
+{
+    public Transform target;
+    public Vector3 offset = new Vector3(0, 5, -10);
+    public float followSpeed = 5f;
+    public float rotationSpeed = 70f;
+    public float zoomSpeed = 5f;
+    public float minZoom = 3f;
+    public float maxZoom = 15f;
+
+    void LateUpdate()
+    {
+        if (target == null)
+            return;
+
+        // Follow the target smoothly.
+        Vector3 desiredPosition = target.position + offset;
+        transform.position = Vector3.Lerp(transform.position, desiredPosition, followSpeed * Time.deltaTime);
+
+        // Zoom based on mouse wheel input.
+        float scroll = Input.GetAxis("Mouse ScrollWheel");
+        offset += offset.normalized * (-scroll * zoomSpeed);
+        offset = Vector3.ClampMagnitude(offset, maxZoom);
+        if (offset.magnitude < minZoom)
+            offset = offset.normalized * minZoom;
+
+        // Allow basic free-look rotation around the target.
+        float horizontal = Input.GetAxis("Mouse X") * rotationSpeed * Time.deltaTime;
+        transform.RotateAround(target.position, Vector3.up, horizontal);
+    }
+}

--- a/unity-prototype/Assets/Scripts/EnemyAI.cs
+++ b/unity-prototype/Assets/Scripts/EnemyAI.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+[RequireComponent(typeof(UnityEngine.AI.NavMeshAgent))]
+public class EnemyAI : MonoBehaviour
+{
+    public Transform target;
+    public float detectionRange = 10f;
+
+    private UnityEngine.AI.NavMeshAgent _agent;
+
+    void Awake()
+    {
+        _agent = GetComponent<UnityEngine.AI.NavMeshAgent>();
+    }
+
+    void Update()
+    {
+        if (target == null)
+            return;
+
+        float distance = Vector3.Distance(transform.position, target.position);
+        if (distance <= detectionRange)
+        {
+            _agent.SetDestination(target.position);
+        }
+    }
+}

--- a/unity-prototype/Assets/Scripts/GameManager.cs
+++ b/unity-prototype/Assets/Scripts/GameManager.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Maintains overall game state such as score and player health.
+/// Handles restarting levels and basic scene transitions.
+/// </summary>
+public class GameManager : MonoBehaviour
+{
+    public static GameManager Instance { get; private set; }
+
+    public int score;
+    public int playerHealth = 3;
+
+    void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+        }
+        else
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+    }
+
+    public void AddScore(int value)
+    {
+        score += value;
+    }
+
+    public void TakeDamage(int amount)
+    {
+        playerHealth -= amount;
+        if (playerHealth <= 0)
+        {
+            RestartLevel();
+        }
+    }
+
+    public void RestartLevel()
+    {
+        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+    }
+
+    public void LoadScene(string name)
+    {
+        SceneManager.LoadScene(name);
+    }
+
+    public void Quit()
+    {
+        Application.Quit();
+    }
+}

--- a/unity-prototype/Assets/Scripts/Health.cs
+++ b/unity-prototype/Assets/Scripts/Health.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+using System;
+
+/// <summary>
+/// Handles hit points and damage for a character or object.
+/// </summary>
+public class Health : MonoBehaviour
+{
+    public int maxHealth = 5;
+    public int currentHealth;
+
+    public event Action OnDeath;
+
+    void Awake()
+    {
+        currentHealth = maxHealth;
+    }
+
+    public void TakeDamage(int amount)
+    {
+        currentHealth -= amount;
+        if (currentHealth <= 0)
+        {
+            currentHealth = 0;
+            if (OnDeath != null)
+            {
+                OnDeath.Invoke();
+            }
+        }
+    }
+
+    public void Heal(int amount)
+    {
+        currentHealth = Mathf.Min(currentHealth + amount, maxHealth);
+    }
+}

--- a/unity-prototype/Assets/Scripts/InputManager.cs
+++ b/unity-prototype/Assets/Scripts/InputManager.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+/// <summary>
+/// Centralized input access for common actions.
+/// </summary>
+public class InputManager : MonoBehaviour
+{
+    public static InputManager Instance { get; private set; }
+
+    void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+        }
+        else
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+    }
+
+    public bool GetJump()
+    {
+        return Input.GetButtonDown("Jump");
+    }
+
+    public bool GetFire()
+    {
+        return Input.GetButtonDown("Fire1");
+    }
+
+    public Vector2 GetMove()
+    {
+        return new Vector2(Input.GetAxis("Horizontal"), Input.GetAxis("Vertical"));
+    }
+
+    public bool GetPause()
+    {
+        return Input.GetKeyDown(KeyCode.Escape);
+    }
+}

--- a/unity-prototype/Assets/Scripts/Inventory.cs
+++ b/unity-prototype/Assets/Scripts/Inventory.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple inventory that tracks collected coins or items.
+/// </summary>
+public class Inventory : MonoBehaviour
+{
+    public int coins;
+
+    public void Add(int amount)
+    {
+        coins += amount;
+    }
+}

--- a/unity-prototype/Assets/Scripts/ItemPickup.cs
+++ b/unity-prototype/Assets/Scripts/ItemPickup.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+/// <summary>
+/// Collectable item that increments the player's inventory on pickup.
+/// </summary>
+public class ItemPickup : MonoBehaviour
+{
+    public int value = 1;
+
+    void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            Inventory inventory = other.GetComponent<Inventory>();
+            if (inventory != null)
+            {
+                inventory.Add(value);
+            }
+            Destroy(gameObject);
+        }
+    }
+}

--- a/unity-prototype/Assets/Scripts/PauseMenu.cs
+++ b/unity-prototype/Assets/Scripts/PauseMenu.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+/// <summary>
+/// Toggles a pause menu and controls game pause state.
+/// </summary>
+public class PauseMenu : MonoBehaviour
+{
+    public GameObject menuUI;
+    private bool _paused;
+
+    void Update()
+    {
+        if (InputManager.Instance != null && InputManager.Instance.GetPause())
+        {
+            TogglePause();
+        }
+    }
+
+    public void TogglePause()
+    {
+        _paused = !_paused;
+        Time.timeScale = _paused ? 0f : 1f;
+        if (menuUI != null)
+            menuUI.SetActive(_paused);
+    }
+
+    public void Quit()
+    {
+        if (GameManager.Instance != null)
+            GameManager.Instance.Quit();
+    }
+}

--- a/unity-prototype/Assets/Scripts/PowerUp.cs
+++ b/unity-prototype/Assets/Scripts/PowerUp.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+using System.Collections;
+
+/// <summary>
+/// Gives the player a temporary boost or heals them when collected.
+/// </summary>
+public class PowerUp : MonoBehaviour
+{
+    public enum Type { Health, Speed }
+    public Type powerType = Type.Health;
+    public int amount = 1;
+    public float duration = 5f;
+
+    void OnTriggerEnter(Collider other)
+    {
+        if (!other.CompareTag("Player"))
+            return;
+
+        if (powerType == Type.Health)
+        {
+            Health health = other.GetComponent<Health>();
+            if (health != null)
+            {
+                health.Heal(amount);
+            }
+        }
+        else if (powerType == Type.Speed)
+        {
+            PlayerController pc = other.GetComponent<PlayerController>();
+            if (pc != null)
+            {
+                StartCoroutine(ApplySpeed(pc));
+            }
+        }
+
+        Destroy(gameObject);
+    }
+
+    private IEnumerator ApplySpeed(PlayerController pc)
+    {
+        float original = pc.moveSpeed;
+        pc.moveSpeed += amount;
+        yield return new WaitForSeconds(duration);
+        pc.moveSpeed = original;
+    }
+}

--- a/unity-prototype/Assets/Scripts/Projectile.cs
+++ b/unity-prototype/Assets/Scripts/Projectile.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple projectile that moves forward and damages objects with a Health component.
+/// </summary>
+public class Projectile : MonoBehaviour
+{
+    public float speed = 10f;
+    public int damage = 1;
+    public float lifetime = 5f;
+
+    void Start()
+    {
+        Destroy(gameObject, lifetime);
+    }
+
+    void Update()
+    {
+        transform.Translate(Vector3.forward * speed * Time.deltaTime);
+    }
+
+    void OnTriggerEnter(Collider other)
+    {
+        Health health = other.GetComponent<Health>();
+        if (health != null)
+        {
+            health.TakeDamage(damage);
+        }
+        Destroy(gameObject);
+    }
+}

--- a/unity-prototype/Assets/Scripts/SceneLoader.cs
+++ b/unity-prototype/Assets/Scripts/SceneLoader.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Provides async scene loading.
+/// </summary>
+public class SceneLoader : MonoBehaviour
+{
+    public void LoadScene(string name)
+    {
+        StartCoroutine(LoadAsync(name));
+    }
+
+    private System.Collections.IEnumerator LoadAsync(string name)
+    {
+        AsyncOperation operation = SceneManager.LoadSceneAsync(name);
+        while (!operation.isDone)
+        {
+            yield return null;
+        }
+    }
+}

--- a/unity-prototype/Assets/Scripts/SpawnManager.cs
+++ b/unity-prototype/Assets/Scripts/SpawnManager.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+/// <summary>
+/// Spawns prefabs at intervals from a list of spawn points.
+/// </summary>
+public class SpawnManager : MonoBehaviour
+{
+    public GameObject prefab;
+    public Transform[] spawnPoints;
+    public float interval = 5f;
+    private float _timer;
+
+    void Update()
+    {
+        _timer += Time.deltaTime;
+        if (_timer >= interval)
+        {
+            Spawn();
+            _timer = 0f;
+        }
+    }
+
+    void Spawn()
+    {
+        if (spawnPoints.Length == 0 || prefab == null)
+            return;
+
+        int index = Random.Range(0, spawnPoints.Length);
+        Instantiate(prefab, spawnPoints[index].position, Quaternion.identity);
+    }
+}

--- a/unity-prototype/Assets/Scripts/UIController.cs
+++ b/unity-prototype/Assets/Scripts/UIController.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Updates HUD elements like score text and health bar.
+/// </summary>
+public class UIController : MonoBehaviour
+{
+    public Text scoreText;
+    public Slider healthSlider;
+
+    void Update()
+    {
+        if (GameManager.Instance == null)
+            return;
+
+        scoreText.text = "Score: " + GameManager.Instance.score;
+        healthSlider.value = GameManager.Instance.playerHealth;
+    }
+}

--- a/unity-prototype/README.md
+++ b/unity-prototype/README.md
@@ -8,4 +8,17 @@ To use this code:
 2. Copy the `Assets` folder from this directory into your Unity project.
 3. Open the project in Unity to continue development.
 
-The included `PlayerController` script shows a basic example of handling keyboard input to move a player character.
+The included scripts demonstrate small gameplay systems:
+
+- `PlayerController` – moves the player using WASD/arrow keys.
+- `CameraController` – smooth follow with zoom and rotation.
+- `GameManager` – tracks score and handles scene changes.
+- `EnemyAI` – moves enemies toward the player when in range.
+- `ItemPickup` and `Inventory` – collectable items and a simple coin counter.
+- `Health` – manages hit points with events on death.
+- `AudioManager` – plays music and sound effects.
+- `UIController` – updates on‑screen score and health.
+- `SpawnManager` – periodically spawns prefabs from spawn points.
+- `InputManager` – central input queries, including a pause action.
+- `SceneLoader` – loads scenes asynchronously.
+- **New:** `Projectile`, `PowerUp`, and `PauseMenu` scripts for shooting, temporary boosts, and pausing the game.


### PR DESCRIPTION
## Summary
- expand Unity example with Projectile, PowerUp and PauseMenu scripts
- update InputManager with a pause query
- document the available Unity scripts

## Testing
- `black . --quiet`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a5028e108321ba9dd612253b9f0e