### PR TITLE
Improve CSV parsing and enforce tweet length

### DIFF
--- a/src/gpt_fusion/analysis.py
+++ b/src/gpt_fusion/analysis.py
@@ -9,7 +9,17 @@ def load_numbers_from_csv(path: str | Path) -> list[float]:
     """Load numbers from a CSV file with a ``value`` column."""
     with open(path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
-        return [float(row["value"]) for row in reader]
+        values: list[float] = []
+        for row in reader:
+            value = row.get("value")
+            if value is None:
+                continue
+            try:
+                values.append(float(value))
+            except ValueError:
+                # Ignore rows that cannot be converted to float
+                continue
+        return values
 
 
 def average_from_csv(path: str | Path) -> float:

--- a/src/gpt_fusion/twitter_bot.py
+++ b/src/gpt_fusion/twitter_bot.py
@@ -47,4 +47,7 @@ class TwitterBot:
 
     def post_tweet(self, message: str) -> None:
         """Post *message* to Twitter."""
+        if len(message) > 280:
+            raise ValueError("Tweet exceeds 280 characters")
+
         self.client.update_status(message)

--- a/src/gpt_fusion/utils.py
+++ b/src/gpt_fusion/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 def add_numbers(a: float, b: float) -> float:
@@ -29,7 +29,7 @@ def divide_numbers(a: float, b: float) -> float:
 class ChatHistory:
     """Simple container for tracking conversation messages."""
 
-    messages: list[str]
+    messages: list[str] = field(default_factory=list)
 
     def add_message(self, text: str) -> None:
         """Append *text* to the history."""

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -20,3 +20,10 @@ def test_average_from_csv():
 
 def test_median_from_csv():
     assert median_from_csv(DATA_PATH) == 3.0
+
+
+def test_load_numbers_from_csv_skips_invalid(tmp_path):
+    csv_path = tmp_path / "nums.csv"
+    csv_path.write_text("value\n1\ninvalid\n2\n\n3\n", encoding="utf-8")
+
+    assert load_numbers_from_csv(csv_path) == [1.0, 2.0, 3.0]

--- a/tests/test_twitter_bot.py
+++ b/tests/test_twitter_bot.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from gpt_fusion.twitter_bot import TwitterBot
 
 
@@ -12,3 +14,10 @@ def test_post_tweet_invokes_tweepy():
         bot.post_tweet("hello")
         api_instance.update_status.assert_called_once_with("hello")
         mock_handler.assert_called_once()
+
+
+def test_post_tweet_long_message_raises_error():
+    with patch("tweepy.OAuth1UserHandler"), patch("tweepy.API"):
+        bot = TwitterBot("k", "s", "t", "c")
+        with pytest.raises(ValueError):
+            bot.post_tweet("x" * 281)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,3 +47,10 @@ def test_clear_chat_history():
 def test_last_message_empty_returns_none():
     history = ChatHistory(messages=[])
     assert history.last_message() is None
+
+
+def test_chathistory_defaults_to_empty_list():
+    history = ChatHistory()
+    assert history.messages == []
+    history.add_message("hi")
+    assert history.last_message() == "hi"


### PR DESCRIPTION
## Summary
- skip invalid rows when reading numbers from CSV
- prevent tweets over 280 characters
- verify new behaviour with additional tests

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872aae839f883219227ca87d14debe6