### PR TITLE
Enhance docs navigation and add page TOCs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Documentation
 
+{% include nav.html %}
+
+<div id="toc"></div>
+
 This project demonstrates small utilities for blending human and AI workflows.
 
 ## Project overview
@@ -70,3 +74,4 @@ and computing averages.
 <script src="assets/js/external-links.js"></script>
 
 <script src="assets/js/anchor-links.js"></script>
+<script src="assets/js/toc.js"></script>

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -1,0 +1,6 @@
+<nav class="navbar" role="navigation" aria-label="Main navigation">
+  <a href="{{ '/' | relative_url }}"{% if page.url == '/' %} class="active" aria-current="page"{% endif %}>Home</a>
+  <a href="{{ '/README.html' | relative_url }}"{% if page.url == '/README.html' %} class="active" aria-current="page"{% endif %}>Overview</a>
+  <a href="{{ '/tutorial.html' | relative_url }}"{% if page.url == '/tutorial.html' %} class="active" aria-current="page"{% endif %}>Tutorial</a>
+  <a href="https://github.com/costasford/gpt-fusion" target="_blank" rel="noopener noreferrer">GitHub</a>
+</nav>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -15,10 +15,43 @@ $section-headings-color: #ec7d0b;
   transition: opacity 0.2s;
 }
 
+
+.navbar {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.navbar a {
+  text-decoration: none;
+}
+
+.navbar a.active {
+  font-weight: bold;
+  text-decoration: underline;
+}
+
 h2:hover .anchor-link,
 h3:hover .anchor-link,
 h4:hover .anchor-link,
 h5:hover .anchor-link,
 h6:hover .anchor-link {
   opacity: 1;
+}
+
+#toc {
+  margin-bottom: 1rem;
+}
+
+#toc ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+#toc li {
+  margin: 0.25rem 0;
+}
+
+#toc a {
+  text-decoration: none;
 }

--- a/docs/assets/js/toc.js
+++ b/docs/assets/js/toc.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('toc');
+  if (!container) return;
+
+  const headings = document.querySelectorAll('h2, h3');
+  if (!headings.length) return;
+
+  const list = document.createElement('ul');
+  container.appendChild(list);
+
+  headings.forEach((h) => {
+    if (!h.id) {
+      const slug = h.textContent
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+      h.id = slug;
+    }
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = `#${h.id}`;
+    a.textContent = h.textContent;
+    li.appendChild(a);
+    list.appendChild(li);
+  });
+});

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,10 @@ layout: default
 title: GPT Fusion Playground
 ---
 
+{% include nav.html %}
+
+<div id="toc"></div>
+
 # GPT Fusion Playground
 
 **Human charm meets algorithmic arm**
@@ -54,3 +58,4 @@ Enjoy fusing ideas with code!
 
 <script src="assets/js/external-links.js"></script>
 <script src="assets/js/anchor-links.js"></script>
+<script src="assets/js/toc.js"></script>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,5 +1,9 @@
 # Tutorial
 
+{% include nav.html %}
+
+<div id="toc"></div>
+
 This short guide shows how to load a sample dataset and compute its average
 value using ``gpt_fusion`` utilities.
 
@@ -27,3 +31,4 @@ print(titles)
 
 <script src="assets/js/external-links.js"></script>
 <script src="assets/js/anchor-links.js"></script>
+<script src="assets/js/toc.js"></script>


### PR DESCRIPTION
## Summary
- add `role` and `aria-label` to the navbar
- open GitHub link with `noopener noreferrer`
- generate a table of contents for documentation pages
- style the TOC in the main stylesheet

## Testing
- `pytest -q`
- `black . --check`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6872aacf430c8321beba497302ca8556