### PR TITLE
Fix docs navigation pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Overview
+---
+
 # Documentation
 
 {% include nav.html %}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Tutorial
+---
+
 # Tutorial
 
 {% include nav.html %}


### PR DESCRIPTION
## Summary
- add Jekyll front matter to Overview and Tutorial pages so the links work

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ec158e7c8321aebc6f0d4cc61f0a