### PR TITLE
Handle network errors in web scraper

### DIFF
--- a/src/gpt_fusion/web_scraper.py
+++ b/src/gpt_fusion/web_scraper.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
 import requests
+from requests.exceptions import RequestException
 from bs4 import BeautifulSoup
 
 
 def scrape(url: str, css_selector: str) -> list[str]:
-    """Return text content of elements matching *css_selector* from *url*."""
-    response = requests.get(url, timeout=10)
-    response.raise_for_status()
+    """Return text content of elements matching *css_selector* from *url*.
+
+    Returns an empty list if the request fails.
+    """
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+    except RequestException:
+        return []
     soup = BeautifulSoup(response.text, "html.parser")
     elements = soup.select(css_selector)
     return [element.get_text(strip=True) for element in elements]

--- a/tests/test_web_scraper.py
+++ b/tests/test_web_scraper.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch
 
+import requests
+
 from gpt_fusion.web_scraper import scrape
 
 
@@ -20,3 +22,13 @@ def test_scrape_parses_text():
         mock_get.assert_called_once_with("http://example.com", timeout=10)
 
     assert result == ["Hello", "World"]
+
+
+def test_scrape_connection_error_returns_empty_list():
+    with patch(
+        "requests.get", side_effect=requests.exceptions.RequestException
+    ) as mock_get:
+        result = scrape("http://example.com", "p.msg")
+        mock_get.assert_called_once_with("http://example.com", timeout=10)
+
+    assert result == []


### PR DESCRIPTION
## Summary
- guard `requests.get` with a try/except block in `scrape`
- return an empty list when a request fails
- test the new behaviour using `patch` to raise `RequestException`

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872fe3c19808321bfbe8bf16b98b638