### PR TITLE
Enhance sharing previews

### DIFF
--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,8 @@
+<meta property="og:title" content="GPT Fusion" />
+<meta property="og:description" content="Human charm meets algorithmic arm" />
+<meta property="og:image" content="/auth-ui-screenshot.png" />
+<meta property="og:type" content="website" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:image" content="/auth-ui-screenshot.png" />
+<meta name="twitter:title" content="GPT Fusion" />
+<meta name="twitter:description" content="Human charm meets algorithmic arm" />

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: GPT Fusion Playground
+image: /auth-ui-screenshot.png
 ---
 
 {% include nav.html %}


### PR DESCRIPTION
## Summary
- add social sharing metadata
- expose preview image in docs front matter

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687323e217d883218a165113de201f0e