### PR TITLE
Improve docs quick link menu styling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,9 @@ title: Overview
 
 {% include nav.html %}
 
-<div id="toc"></div>
+<div id="toc">
+  <p class="toc-title">Quick links</p>
+</div>
 
 This project demonstrates small utilities for blending human and AI workflows.
 

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -41,6 +41,15 @@ h6:hover .anchor-link {
 
 #toc {
   margin-bottom: 1rem;
+  padding: 1rem;
+  background-color: #f8f8f8;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+}
+
+#toc .toc-title {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
 }
 
 #toc ul {
@@ -54,4 +63,5 @@ h6:hover .anchor-link {
 
 #toc a {
   text-decoration: none;
+  color: inherit;
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,9 @@ image: /auth-ui-screenshot.png
 
 {% include nav.html %}
 
-<div id="toc"></div>
+<div id="toc">
+  <p class="toc-title">Quick links</p>
+</div>
 
 # GPT Fusion Playground
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -7,7 +7,9 @@ title: Tutorial
 
 {% include nav.html %}
 
-<div id="toc"></div>
+<div id="toc">
+  <p class="toc-title">Quick links</p>
+</div>
 
 This short guide shows how to load a sample dataset and compute its average
 value using ``gpt_fusion`` utilities.


### PR DESCRIPTION
## Summary
- add a quick links heading in docs pages
- style the quick link menu with padding, border and background color

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68732c1c30648321b45fbd9883d4b3dc