### PR TITLE
Add contribution guide and backend root endpoint

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,12 @@ installing the Jekyll gem, run `jekyll serve` from this folder and open
 See [tutorial.md](tutorial.md) for a walkthrough on loading the sample dataset
 and computing averages.
 
+## Contributing
+
+Interested in helping out? Check the [contributing guide](contributing.md) for
+instructions on formatting, linting, and running tests before submitting a
+pull request.
+
 <script src="assets/js/external-links.js"></script>
 
 <script src="assets/js/anchor-links.js"></script>

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -2,5 +2,6 @@
   <a href="{{ '/' | relative_url }}"{% if page.url == '/' %} class="active" aria-current="page"{% endif %}>Home</a>
   <a href="{{ '/README.html' | relative_url }}"{% if page.url == '/README.html' %} class="active" aria-current="page"{% endif %}>Overview</a>
   <a href="{{ '/tutorial.html' | relative_url }}"{% if page.url == '/tutorial.html' %} class="active" aria-current="page"{% endif %}>Tutorial</a>
+  <a href="{{ '/contributing.html' | relative_url }}"{% if page.url == '/contributing.html' %} class="active" aria-current="page"{% endif %}>Contribute</a>
   <a href="https://github.com/costasford/gpt-fusion" target="_blank" rel="noopener noreferrer">GitHub</a>
 </nav>

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,37 @@
+---
+layout: default
+title: Contribute
+---
+
+{% include nav.html %}
+
+<div id="toc">
+  <p class="toc-title">Quick links</p>
+</div>
+
+# Contributing
+
+We welcome improvements to **gpt-fusion**! Please follow these guidelines to keep
+things consistent.
+
+## Development workflow
+
+- Create a virtual environment and install dev dependencies:
+  ```bash
+  python -m venv .venv
+  source .venv/bin/activate
+  pip install -r requirements-dev.txt
+  ```
+- Run `pre-commit install` so formatting and linting trigger on each commit.
+- Format code with `black .` and lint with `flake8`.
+- Execute the test suite using `pytest -q` before committing.
+
+## Pull requests
+
+Keep changes focused and document your intent. Passing tests and clean linting
+are required before a PR is merged. Summaries should explain the high level goal
+and mention the commands you ran.
+
+<script src="assets/js/external-links.js"></script>
+<script src="assets/js/anchor-links.js"></script>
+<script src="assets/js/toc.js"></script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,11 @@ A basic Unity setup for AI experiments. [Check the repo](https://github.com/cost
 
 Learn how to load sample data and compute averages. [Follow the tutorial](tutorial.md).
 
+### Contribute
+
+Want to get involved? Read the [contributing guide](contributing.md) to learn
+how we format code, lint, and run tests.
+
 Enjoy fusing ideas with code!
 
 <script src="assets/js/external-links.js"></script>

--- a/src/gpt_fusion/backend.py
+++ b/src/gpt_fusion/backend.py
@@ -1,3 +1,5 @@
+"""Minimal FastAPI backend used in the docs and tests."""
+
 from fastapi import FastAPI
 from pydantic import BaseModel
 
@@ -7,6 +9,12 @@ app = FastAPI()
 class Profile(BaseModel):
     uid: str
     display_name: str
+
+
+@app.get("/")
+def read_root() -> dict[str, str]:
+    """Return a short welcome message."""
+    return {"message": "gpt-fusion backend"}
 
 
 @app.get("/profile/{uid}", response_model=Profile)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -4,6 +4,12 @@ from gpt_fusion.backend import app
 client = TestClient(app)
 
 
+def test_read_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "gpt-fusion backend"}
+
+
 def test_get_profile():
     response = client.get("/profile/test")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- create docs/contributing.md with workflow tips
- link contribution guide in site nav and docs pages
- add root endpoint and docstring to backend
- test new backend endpoint

## Testing
- `black . --quiet`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732ff2c0d48321af5684cf07346df8