### PR TITLE
Add documentation for AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,12 @@ Always run the unit tests with `pytest -q` before committing changes.
 
 Run `black .` to format code and `flake8` to lint. Fix any issues before committing.
 
+## Documentation
+
+Keep the README and docs in sync with new features. Build the site with
+`jekyll build` to verify pages render. A copy of these guidelines is published
+at [docs/guidelines.md](docs/guidelines.md).
+
 ## Pull request messages
 
 Summaries should describe the high level goal of the change. Include a short **Testing** section that lists the commands run and whether they succeeded.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,8 @@ the site locally:
 1. Install Ruby and the Jekyll gem: `gem install jekyll`.
 2. Run `jekyll serve` from the `docs/` directory.
 3. Open <http://localhost:4000> in your browser to explore the docs.
+
+## Contributing
+
+Development guidelines for Codex are recorded in [AGENTS.md](AGENTS.md).
+You can also read them on the website at [docs/guidelines.md](docs/guidelines.md).

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -3,5 +3,6 @@
   <a href="{{ '/README.html' | relative_url }}"{% if page.url == '/README.html' %} class="active" aria-current="page"{% endif %}>Overview</a>
   <a href="{{ '/tutorial.html' | relative_url }}"{% if page.url == '/tutorial.html' %} class="active" aria-current="page"{% endif %}>Tutorial</a>
   <a href="{{ '/contributing.html' | relative_url }}"{% if page.url == '/contributing.html' %} class="active" aria-current="page"{% endif %}>Contribute</a>
+  <a href="{{ '/guidelines.html' | relative_url }}"{% if page.url == '/guidelines.html' %} class="active" aria-current="page"{% endif %}>Guidelines</a>
   <a href="https://github.com/costasford/gpt-fusion" target="_blank" rel="noopener noreferrer">GitHub</a>
 </nav>

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,7 +12,8 @@ title: Contribute
 # Contributing
 
 We welcome improvements to **gpt-fusion**! Please follow these guidelines to keep
-things consistent.
+things consistent. The full instructions used by Codex are listed on the
+[Guidelines](guidelines.md) page.
 
 ## Development workflow
 

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Agent Guidelines
+---
+
+{% include nav.html %}
+
+<div id="toc">
+  <p class="toc-title">Quick links</p>
+</div>
+
+This page summarizes the instructions in [AGENTS.md](../AGENTS.md) for AI-based contributors.
+
+## Testing
+
+Always run `pytest -q` before committing changes.
+
+## Formatting and linting
+
+Run `black .` to format code and `flake8` to lint. Fix any issues before committing.
+
+## Pull requests
+
+Summaries should describe the high level goal of the change and include a short **Testing** section listing the commands run and whether they succeeded.
+
+## Project direction
+
+- Keep modules small and focused.
+- Document new interfaces with docstrings and examples.
+- Maintain cross-platform compatibility where reasonable.
+- Expand the test suite for new functionality.
+- Write helpful commit messages and PR summaries explaining the intent of your changes.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,8 @@ Learn how to load sample data and compute averages. [Follow the tutorial](tutori
 ### Contribute
 
 Want to get involved? Read the [contributing guide](contributing.md) to learn
-how we format code, lint, and run tests.
+how we format code, lint, and run tests. The detailed rules used by Codex are
+listed on the [Guidelines](guidelines.md) page.
 
 Enjoy fusing ideas with code!
 


### PR DESCRIPTION
## Summary
- add docs/guidelines page for agents instructions
- cross reference guidelines from navigation and contributing docs
- mention guidelines in README
- expand AGENTS.md with documentation notes

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687331e8a390832189a3555177924b81