### PR TITLE
Update contributor docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,34 +1,44 @@
-# AGENTS instructions for gpt-fusion
+# Agent guidelines for gpt-fusion
 
-Codex should follow these guidelines when contributing to this repository.
+Codex must follow these steps when contributing to this repository.
 
-## Testing
+## Setup
 
-Always run the unit tests with `pytest -q` before committing changes.
+- Use Python 3.8 or newer.
+- Install development dependencies:
+  ```bash
+  pip install -r requirements-dev.txt
+  pre-commit install
+  ```
 
-## Formatting and linting
+## Testing and quality checks
 
-Run `black .` to format code and `flake8` to lint. Fix any issues before committing.
+1. Format and lint the project:
+   ```bash
+   black .
+   flake8
+   ```
+2. Run the unit tests:
+   ```bash
+   pytest -q
+   ```
+3. Build the documentation to verify pages render:
+   ```bash
+   jekyll build
+   ```
+   Fix any issues before committing.
 
-## Documentation
+## Pull requests
 
-Keep the README and docs in sync with new features. Build the site with
-`jekyll build` to verify pages render. A copy of these guidelines is published
-at [docs/guidelines.md](docs/guidelines.md).
-
-## Pull request messages
-
-Summaries should describe the high level goal of the change. Include a short **Testing** section that lists the commands run and whether they succeeded.
+- Summaries should describe the high level goal of the change.
+- Include a **Testing** section listing the commands run and whether they succeeded.
 
 ## Project direction
-
-The goal of *gpt-fusion* is to demonstrate how human and AI contributions can
-blend into clear, maintainable tooling. When adding features or fixing bugs,
-keep the following principles in mind:
 
 - Keep modules small and focused so others can easily reuse them.
 - Document new interfaces with docstrings and practical examples.
 - Maintain cross-platform compatibility where reasonable.
 - Expand the test suite for any new functionality.
-- Write helpful commit messages and PR summaries explaining the intent of your
-  changes.
+- Write helpful commit messages and PR summaries explaining the intent of your changes.
+
+A copy of these guidelines is available at [docs/guidelines.md](docs/guidelines.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,6 +26,7 @@ things consistent. The full instructions used by Codex are listed on the
 - Run `pre-commit install` so formatting and linting trigger on each commit.
 - Format code with `black .` and lint with `flake8`.
 - Execute the test suite using `pytest -q` before committing.
+- Build the docs with `jekyll build` to ensure pages render.
 
 ## Pull requests
 

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -9,19 +9,38 @@ title: Agent Guidelines
   <p class="toc-title">Quick links</p>
 </div>
 
-This page summarizes the instructions in [AGENTS.md](../AGENTS.md) for AI-based contributors.
+This page mirrors the instructions in [AGENTS.md](../AGENTS.md) for AI-based contributors.
 
-## Testing
+## Setup
 
-Always run `pytest -q` before committing changes.
+- Use Python 3.8 or newer.
+- Install development dependencies:
+  ```bash
+  pip install -r requirements-dev.txt
+  pre-commit install
+  ```
 
-## Formatting and linting
+## Testing and quality checks
 
-Run `black .` to format code and `flake8` to lint. Fix any issues before committing.
+1. Format and lint the project:
+   ```bash
+   black .
+   flake8
+   ```
+2. Run the unit tests:
+   ```bash
+   pytest -q
+   ```
+3. Build the docs to verify pages render:
+   ```bash
+   jekyll build
+   ```
+   Fix any issues before committing.
 
 ## Pull requests
 
-Summaries should describe the high level goal of the change and include a short **Testing** section listing the commands run and whether they succeeded.
+- Summaries should describe the high level goal of the change.
+- Include a **Testing** section listing the commands run and whether they succeeded.
 
 ## Project direction
 
@@ -30,4 +49,3 @@ Summaries should describe the high level goal of the change and include a short 
 - Maintain cross-platform compatibility where reasonable.
 - Expand the test suite for new functionality.
 - Write helpful commit messages and PR summaries explaining the intent of your changes.
-


### PR DESCRIPTION
## Summary
- clarify agent instructions with setup and testing steps
- include the same guidelines in the docs
- mention `jekyll build` in the contributing guide

## Testing
- `black .`
- `flake8`
- `pytest -q`
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68733523011883218e6f56ccbf158d15