### PR TITLE
Add project overview page and sync guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,4 +41,6 @@ Codex must follow these steps when contributing to this repository.
 - Expand the test suite for any new functionality.
 - Write helpful commit messages and PR summaries explaining the intent of your changes.
 
+If you modify this file, update [docs/guidelines.md](docs/guidelines.md) to keep the website in sync.
+
 A copy of these guidelines is available at [docs/guidelines.md](docs/guidelines.md).

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ and `unity-prototype/` for a basic Unity setup. Copy the `Assets` directory into
 a new Unity project (tested with Unity&nbsp;2021 or later) to experiment with the
 included movement and interaction scripts.
 
+A summary of these demos is available in [docs/projects.md](docs/projects.md).
+
 ## Data
 
 The `data/` directory contains a small `numbers.csv` file used in tutorials and

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,8 @@ matched:
   scripts. Useful for exploring AI behaviour in a 3D environment.
 - **Documentation** – these markdown files, rendered using Jekyll.
 
+See [projects.md](projects.md) for a concise overview of each sample.
+
 Each component is small on its own, but together they highlight different ways
 to fuse code written by humans and AI tools.
 

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -1,6 +1,7 @@
 <nav class="navbar" role="navigation" aria-label="Main navigation">
   <a href="{{ '/' | relative_url }}"{% if page.url == '/' %} class="active" aria-current="page"{% endif %}>Home</a>
   <a href="{{ '/README.html' | relative_url }}"{% if page.url == '/README.html' %} class="active" aria-current="page"{% endif %}>Overview</a>
+  <a href="{{ '/projects.html' | relative_url }}"{% if page.url == '/projects.html' %} class="active" aria-current="page"{% endif %}>Projects</a>
   <a href="{{ '/tutorial.html' | relative_url }}"{% if page.url == '/tutorial.html' %} class="active" aria-current="page"{% endif %}>Tutorial</a>
   <a href="{{ '/contributing.html' | relative_url }}"{% if page.url == '/contributing.html' %} class="active" aria-current="page"{% endif %}>Contribute</a>
   <a href="{{ '/guidelines.html' | relative_url }}"{% if page.url == '/guidelines.html' %} class="active" aria-current="page"{% endif %}>Guidelines</a>

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -49,3 +49,5 @@ This page mirrors the instructions in [AGENTS.md](../AGENTS.md) for AI-based con
 - Maintain cross-platform compatibility where reasonable.
 - Expand the test suite for new functionality.
 - Write helpful commit messages and PR summaries explaining the intent of your changes.
+
+If this page diverges from [AGENTS.md](../AGENTS.md), please update both files so the instructions stay consistent.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,8 @@ see how tests and tutorials tie the components together.
 
 ## Projects
 
+More information about each demo lives on the [Projects page](projects.md).
+
 ### Python utilities
 
 Reusable helpers for greetings, math and simple CSV analysis. [Read the docs](README.md).
@@ -47,7 +49,7 @@ and Google sign in flows. The UI also includes sign-up and password reset
 dialogs for quick experimentation.
 [View the demo](https://github.com/costasford/gpt-fusion/tree/main/auth-ui-kit).
 
-![Auth UI screenshot](assets/auth-ui-screenshot.png)
+![Auth UI screenshot](/auth-ui-screenshot.png)
 
 ### Unity prototype
 
@@ -55,7 +57,6 @@ A small 3D demo showcasing simple movement and item pickups. Copy the `Assets`
 folder into a new Unity project (tested with Unity&nbsp;2021 or later) and run the
 scene to explore. [Check the repo](https://github.com/costasford/gpt-fusion/tree/main/unity-prototype).
 
-![Unity demo](assets/unity-demo.png)
 
 ### Tutorial
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,0 +1,34 @@
+---
+layout: default
+title: Projects
+---
+
+{% include nav.html %}
+
+<div id="toc">
+  <p class="toc-title">Quick links</p>
+</div>
+
+# Projects
+
+The repository hosts a few small demos showcasing different aspects of human‑AI collaboration. This page summarises each component and links to further details.
+
+## Python utilities
+
+The `gpt_fusion` package provides greeting helpers, math functions and simple CSV readers used throughout the tutorials. See the [package README](../README.md#project-layout) for an overview.
+
+## Auth UI Kit
+
+A Tailwind‑styled login form powered by Firebase. Update `auth-ui-kit/app.js` with your project credentials and serve the folder locally to experiment with email/password and Google sign in flows.
+
+## Unity prototype
+
+A basic 3D scene demonstrating player movement, item pickups and simple enemy AI. Copy the `Assets` directory from `unity-prototype/` into a new Unity project (Unity 2021 or later).
+
+## Tutorial
+
+Walk through loading the sample dataset and computing averages in [tutorial.md](tutorial.md).
+
+<script src="assets/js/external-links.js"></script>
+<script src="assets/js/anchor-links.js"></script>
+<script src="assets/js/toc.js"></script>


### PR DESCRIPTION
## Summary
- document project demos in a new `docs/projects.md`
- link to the new page from the navigation bar and docs
- remove broken image, fix screenshot path in index
- note that changes to AGENTS.md must also update docs

## Testing
- `pip install -r requirements-dev.txt`
- `pre-commit install`
- `black .`
- `flake8`
- `pytest -q`
- `jekyll build --source docs --destination docs/_site`

------
https://chatgpt.com/codex/tasks/task_e_6873391269348321956d946dffa449da