### PR TITLE
Add examples folder and ignore docs build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ htmlcov/
 # Misc
 *.log
 docs/assets/*.png
+
+docs/_site/
+docs/.jekyll-cache/
+.jekyll-cache/

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,4 @@
+# Example Scripts
+
+This folder contains small Python scripts demonstrating how to use the
+`gpt_fusion` package. Run them with `python <script>` from the project root.

--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from gpt_fusion import load_numbers_from_csv, average_from_csv, median_from_csv
+
+
+def main() -> None:
+    csv_path = Path(__file__).resolve().parents[1] / "data" / "numbers.csv"
+    values = load_numbers_from_csv(csv_path)
+    print("Values:", values)
+    print("Average:", average_from_csv(csv_path))
+    print("Median:", median_from_csv(csv_path))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- avoid committing Jekyll build outputs by ignoring docs/_site and cache directories
- provide an example script under `examples/` demonstrating how to load and analyze the sample CSV data

## Testing
- `black .`
- `flake8`
- `pytest -q`
- `cd docs && jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68734054636c83219ae1a19983d83105