### PR TITLE
Remove duplicate GitHub button

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,4 +2,4 @@ theme: jekyll-theme-cayman
 title: GPT Fusion
 description: Practical demos of human-AI collaboration
 github:
-  is_project_page: true
+  is_project_page: false


### PR DESCRIPTION
## Summary
- disable the `jekyll-theme-cayman` GitHub banner

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `jekyll build -s docs -d /tmp/jekyll`

------
https://chatgpt.com/codex/tasks/task_e_68734aeeea048321953a8518b58f036d