### PR TITLE
Add API endpoint for project list

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,10 @@ from `unity-prototype`. The included scripts handle basic movement, camera
 control, item pickups and pausing the game. Play the scene to explore how these
 pieces interact.
 
+### Project API
+
+Run `uvicorn gpt_fusion.backend:app` to start the example FastAPI server. It exposes a `/projects` route that returns the demo list in JSON form.
+
 ### Serving the docs locally
 
 The documentation is built with [Jekyll](https://jekyllrb.com/). After

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -11,7 +11,7 @@ title: Projects
 
 # Projects
 
-The repository hosts a few small demos showcasing different aspects of human‑AI collaboration. This page summarises each component and links to further details.
+The repository hosts a few small demos showcasing different aspects of human‑AI collaboration. This page summarises each component and links to further details. The optional API server exposes these entries at the `/projects` route so you can fetch them programmatically.
 
 ## Python utilities
 

--- a/src/gpt_fusion/__init__.py
+++ b/src/gpt_fusion/__init__.py
@@ -4,6 +4,7 @@ from .analysis import average_from_csv, load_numbers_from_csv, median_from_csv
 from .core import greet
 from .web_scraper import scrape
 from .backend import app as backend_app
+from .projects import PROJECTS, Project
 from .twitter_bot import TwitterBot
 from .twitch import TwitchClient
 from .utils import (
@@ -46,4 +47,6 @@ __all__ = [
     "TwitterBot",
     "TwitchClient",
     "backend_app",
+    "Project",
+    "PROJECTS",
 ]

--- a/src/gpt_fusion/backend.py
+++ b/src/gpt_fusion/backend.py
@@ -3,6 +3,8 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
 
+from .projects import PROJECTS, Project
+
 app = FastAPI()
 
 
@@ -20,3 +22,9 @@ def read_root() -> dict[str, str]:
 @app.get("/profile/{uid}", response_model=Profile)
 def get_profile(uid: str):
     return Profile(uid=uid, display_name=f"User {uid}")
+
+
+@app.get("/projects", response_model=list[Project])
+def list_projects() -> list[Project]:
+    """Return the sample projects bundled with the repo."""
+    return PROJECTS

--- a/src/gpt_fusion/projects.py
+++ b/src/gpt_fusion/projects.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Project:
+    """Small description of a demo project."""
+
+    id: str
+    name: str
+    description: str
+
+
+PROJECTS: list[Project] = [
+    Project(
+        id="python-utilities",
+        name="Python utilities",
+        description=(
+            "Greeting helpers, math functions, text utilities and a small CSV "
+            "reader. Includes a web scraper, Twitter bot and optional FastAPI backend."
+        ),
+    ),
+    Project(
+        id="auth-ui-kit",
+        name="Auth UI Kit",
+        description=(
+            "Tailwind-styled login form powered by Firebase for experimenting with "
+            "email/password and Google sign in flows."
+        ),
+    ),
+    Project(
+        id="unity-prototype",
+        name="Unity prototype",
+        description=(
+            "Basic 3D scene demonstrating player movement, item pickups and simple "
+            "enemy AI."
+        ),
+    ),
+    Project(
+        id="top-viewer-games",
+        name="Top Viewer Games",
+        description=(
+            "Shows current popular Twitch channels and games using the Twitch API."
+        ),
+    ),
+    Project(
+        id="tutorial",
+        name="Tutorial",
+        description="Walkthrough for loading sample data and computing averages.",
+    ),
+]
+
+__all__ = ["Project", "PROJECTS"]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -14,3 +14,10 @@ def test_get_profile():
     response = client.get("/profile/test")
     assert response.status_code == 200
     assert response.json() == {"uid": "test", "display_name": "User test"}
+
+
+def test_list_projects():
+    response = client.get("/projects")
+    assert response.status_code == 200
+    data = response.json()
+    assert any(p["id"] == "auth-ui-kit" for p in data)


### PR DESCRIPTION
## Summary
- add a `Project` dataclass and `PROJECTS` registry
- expose `/projects` FastAPI route
- export project info in package init
- document example API usage in the docs
- test the new route

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6873df221ae08321b142200caecaa02f