### PR TITLE
Add return type to get_profile

### DIFF
--- a/src/gpt_fusion/backend.py
+++ b/src/gpt_fusion/backend.py
@@ -18,5 +18,6 @@ def read_root() -> dict[str, str]:
 
 
 @app.get("/profile/{uid}", response_model=Profile)
-def get_profile(uid: str):
+def get_profile(uid: str) -> Profile:
+    """Return a basic profile for the given user id."""
     return Profile(uid=uid, display_name=f"User {uid}")


### PR DESCRIPTION
## Summary
- add `Profile` return type to `get_profile` endpoint
- document `/profile/{uid}` endpoint

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6873dffd12b083218a0c8d3b39dd5220