### PR TITLE
Add Jekyll build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+      - name: Install Ruby gems
+        run: |
+          gem install jekyll jekyll-theme-cayman --no-document
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -23,4 +29,6 @@ jobs:
           flake8
       - name: Test
         run: pytest -q
+      - name: Build documentation
+        run: jekyll build -s docs -d docs/_site
 


### PR DESCRIPTION
## Summary
- install Ruby and Jekyll in CI
- run `jekyll build` after tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `jekyll build -s docs -d docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_6873dffc12288321a488a3c4ef7a426a