### PR TITLE
Update CI to test multiple Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- run CI on Python 3.8 through 3.12

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `cd docs && jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_6873dffba85c8321a152836ef5eba6a5