### PR TITLE
Switch CI linting to pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
+      - name: Set up pre-commit
+        run: pre-commit install
       - name: Lint
-        run: |
-          black --check .
-          flake8
+        run: pre-commit run --all-files
       - name: Test
         run: pytest -q
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Twitter bot utilities.
 1. **Environment**: Use Python 3.8+.
 2. **Dependencies**: Install the development requirements with `pip install -r requirements-dev.txt`. The core library uses only the Python standard library, but the optional Twitter bot requires [tweepy](https://www.tweepy.org/).
    Runtime extras can be installed with `pip install gpt-fusion[backend,twitter]`.
-3. **Style**: Format code with [black](https://github.com/psf/black) and lint with [flake8](https://github.com/PyCQA/flake8). A [pre-commit](https://pre-commit.com) hook runs these automatically.
+3. **Style**: Run `pre-commit run --all-files` to format and lint the code. A [pre-commit](https://pre-commit.com) hook runs these checks automatically.
 4. **Tests**: Run `pytest` before submitting changes.
 5. **Hooks**: After installing dependencies, run `pre-commit install` so formatting and linting run on each commit.
 6. **CI**: GitHub Actions runs formatting checks and the test suite on every pull request.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,7 +24,7 @@ things consistent. The full instructions used by Codex are listed on the
   pip install -r requirements-dev.txt
   ```
 - Run `pre-commit install` so formatting and linting trigger on each commit.
-- Format code with `black .` and lint with `flake8`.
+- Run `pre-commit run --all-files` to format and lint the code.
 - Execute the test suite using `pytest -q` before committing.
 - Build the docs with `jekyll build` to ensure pages render.
 

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -22,11 +22,10 @@ This page mirrors the instructions in [AGENTS.md](../AGENTS.md) for AI-based con
 
 ## Testing and quality checks
 
-1. Format and lint the project using the `pre-commit` hook:
+1. Format and lint the project using `pre-commit`:
    ```bash
    pre-commit run --all-files
    ```
-   You can also run `black .` and `flake8` directly.
 2. Run the unit tests:
    ```bash
    pytest -q


### PR DESCRIPTION
## Summary
- use `pre-commit` in CI instead of running black & flake8 manually
- document using `pre-commit run --all-files`

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6873dffd473c8321a2309df9c4727619