### PR TITLE
Add sustainability docs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/README.md
+++ b/README.md
@@ -92,3 +92,7 @@ the site locally:
 
 Development guidelines for Codex are recorded in [AGENTS.md](AGENTS.md).
 You can also read them on the website at [docs/guidelines.md](docs/guidelines.md).
+
+## Sustainability
+
+For tips on keeping the repository healthy over time, see the [Sustainability Guide](docs/sustainability.md). It covers routine dependency updates, security checks, and best practices for maintaining the docs and tests.

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,6 +113,8 @@ Interested in helping out? Check the [contributing guide](contributing.md) for
 instructions on formatting, linting, and running tests before submitting a
 pull request.
 
+For ongoing maintenance tips, see the [Sustainability Guide](sustainability.md).
+
 <script src="assets/js/external-links.js"></script>
 
 <script src="assets/js/anchor-links.js"></script>

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -6,5 +6,6 @@
   <a href="{{ '/tutorial.html' | relative_url }}"{% if page.url == '/tutorial.html' %} class="active" aria-current="page"{% endif %}>Tutorial</a>
   <a href="{{ '/contributing.html' | relative_url }}"{% if page.url == '/contributing.html' %} class="active" aria-current="page"{% endif %}>Contribute</a>
   <a href="{{ '/guidelines.html' | relative_url }}"{% if page.url == '/guidelines.html' %} class="active" aria-current="page"{% endif %}>Guidelines</a>
+  <a href="{{ '/sustainability.html' | relative_url }}"{% if page.url == '/sustainability.html' %} class="active" aria-current="page"{% endif %}>Sustainability</a>
   <a href="https://github.com/costasford/gpt-fusion" target="_blank" rel="noopener noreferrer">GitHub</a>
 </nav>

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ image: /auth-ui-screenshot.png
     <p>Learn how to load sample data and compute averages. <a href="tutorial.md">Follow the tutorial</a>.</p>
     <h3>Contribute</h3>
     <p>Want to get involved? Read the <a href="contributing.md">contributing guide</a> to learn how we format code, lint, and run tests. The detailed rules used by Codex are listed on the <a href="guidelines.md">Guidelines page</a>.</p>
+    <p>For ongoing care of the project, consult the <a href="sustainability.md">Sustainability Guide</a> which covers dependency updates and general maintenance tips.</p>
     <p>Enjoy fusing ideas with code!</p>
   </section>
 </div>

--- a/docs/sustainability.md
+++ b/docs/sustainability.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Sustainability Guide
+---
+
+{% include nav.html %}
+
+# Long-term maintenance
+
+Keeping the repository healthy ensures others can reuse these examples far into the future. Follow these practices to sustain the project over time.
+
+## Regular upkeep
+
+- **Keep dependencies current**. Run `pip list --outdated` and update packages in `requirements-dev.txt` when new versions are released.
+- **Check for security issues**. Tools like `pip-audit` or GitHub's Dependabot can highlight vulnerabilities.
+- **Verify builds**. Always run `pre-commit run --all-files`, `pytest -q`, and `jekyll build` before merging changes.
+- **Document significant changes**. Update the relevant markdown files and docstrings so new contributors understand the latest behaviour.
+
+## Project health
+
+- Aim for small, focused modules with clear tests.
+- Keep the CI workflow green. Fix failing jobs quickly to avoid regressions.
+- Review pull requests thoroughly to maintain code quality.
+
+With routine attention the project can serve as a lasting reference for human–AI collaboration.


### PR DESCRIPTION
## Summary
- document long-term repository maintenance
- link to Sustainability guide from navigation and documentation
- configure Flake8 max line length to match Black

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_6873e22de264832182e2569912372440