### PR TITLE
Improve docs styling

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -7,6 +7,10 @@ $section-headings-color: #ec7d0b;
 
 @import "{{ site.theme }}";
 
+html {
+  scroll-behavior: smooth;
+}
+
 .anchor-link {
   margin-left: 0.25rem;
   font-size: 0.8em;

--- a/src/gpt_fusion/projects.py
+++ b/src/gpt_fusion/projects.py
@@ -17,37 +17,46 @@ PROJECTS: list[Project] = [
         id="python-utilities",
         name="Python utilities",
         description=(
-            "Greeting helpers, math functions, text utilities and a small CSV "
-            "reader. Includes a web scraper, Twitter bot and optional FastAPI backend."
+            "Greeting helpers, math functions, text utilities and a small "
+            "CSV reader. Includes a web scraper, Twitter bot and optional "
+            "FastAPI backend."
         ),
     ),
     Project(
         id="auth-ui-kit",
         name="Auth UI Kit",
         description=(
-            "Tailwind-styled login form powered by Firebase for experimenting with "
-            "email/password and Google sign in flows."
+            "Tailwind-styled login form powered by Firebase for "
+            "experimenting with email/password and Google sign in flows."
         ),
     ),
     Project(
         id="unity-prototype",
         name="Unity prototype",
         description=(
-            "Basic 3D scene demonstrating player movement, item pickups and simple "
-            "enemy AI."
+            "Basic 3D scene demonstrating player movement, item pickups "
+            "and simple enemy AI."
         ),
     ),
     Project(
         id="top-viewer-games",
         name="Top Viewer Games",
         description=(
-            "Shows current popular Twitch channels and games using the Twitch API."
+            # fmt: off
+            "Shows current popular Twitch channels and games "
+            "using the Twitch API."
+            # fmt: on
         ),
     ),
     Project(
         id="tutorial",
         name="Tutorial",
-        description="Walkthrough for loading sample data and computing averages.",
+        description=(
+            # fmt: off
+            "Walkthrough for loading sample data and "
+            "computing averages."
+            # fmt: on
+        ),
     ),
 ]
 


### PR DESCRIPTION
## Summary
- resolve flake8 line length issues
- enable smooth page scrolling for docs

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `jekyll build -s docs -d docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_6873e24156b8832189e9856d7e55568e