### PR TITLE
Fix Python 3.8 compatibility

### DIFF
--- a/src/gpt_fusion/backend.py
+++ b/src/gpt_fusion/backend.py
@@ -1,5 +1,7 @@
 """Minimal FastAPI backend used in the docs and tests."""
 
+from __future__ import annotations
+
 from fastapi import FastAPI
 from pydantic import BaseModel
 


### PR DESCRIPTION
## Summary
- ensure FastAPI backend supports Python 3.8 by using `from __future__ import annotations`

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `python3.12 -m pytest -q`
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6873e4c7551c832194c2f85c76185043