### PR TITLE
fix: lazy load optional modules and update extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,20 +28,20 @@ data/           # sample data
 
 ## Installation
 
-Install the library with the optional backend and Twitter extras:
+Install the library with the optional backend, Twitter and web scraping extras:
 
 ```bash
-pip install "gpt-fusion[backend,twitter]"
+pip install "gpt-fusion[backend,twitter,web]"
 ```
 
-These extras pull in FastAPI for the example API server and Tweepy for the
-Twitter bot utilities.
+These extras pull in FastAPI for the example API server, Tweepy for the
+Twitter bot utilities, and Requests/BeautifulSoup for the scraping helpers.
 
 ## Development workflow
 
 1. **Environment**: Use Python 3.8+.
-2. **Dependencies**: Install the development requirements with `pip install -r requirements-dev.txt`. The core library uses only the Python standard library, but the optional Twitter bot requires [tweepy](https://www.tweepy.org/).
-   Runtime extras can be installed with `pip install gpt-fusion[backend,twitter]`.
+2. **Dependencies**: Install the development requirements with `pip install -r requirements-dev.txt`. The core modules rely only on the Python standard library, while optional components require extra packages.
+   Runtime extras can be installed with `pip install gpt-fusion[backend,twitter,web]`.
 3. **Style**: Run `pre-commit run --all-files` to format and lint the code. A [pre-commit](https://pre-commit.com) hook runs these checks automatically.
 4. **Tests**: Run `pytest` before submitting changes.
 5. **Hooks**: After installing dependencies, run `pre-commit install` so formatting and linting run on each commit.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -25,10 +25,10 @@ cd gpt-fusion
 pip install -e .
 ```
 
-To explore the optional API server and Twitter helpers install the extras:
+To explore the optional API server, web scraper and Twitter helpers install the extras:
 
 ```bash
-pip install "gpt-fusion[backend,twitter]"
+pip install "gpt-fusion[backend,twitter,web]"
 ```
 
 ## Loading sample data

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gpt-fusion",
   "version": "1.0.0",
   "description": "[![CI Status](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg)](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml)",
-  "main": "index.js",
+  "main": "auth-ui-kit/app.js",
   "directories": {
     "doc": "docs",
     "example": "examples",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,7 @@ authors = [{name="Costas Ford", email="costasford@yahoo.com"}]
 readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.8"
-dependencies = [
-    "requests",
-    "beautifulsoup4",
-]
+dependencies = []
 
 [project.optional-dependencies]
 backend = [
@@ -22,6 +19,10 @@ backend = [
 ]
 twitter = [
     "tweepy",
+]
+web = [
+    "requests",
+    "beautifulsoup4",
 ]
 
 [tool.pytest.ini_options]

--- a/src/gpt_fusion/__init__.py
+++ b/src/gpt_fusion/__init__.py
@@ -1,12 +1,12 @@
 """Top-level package for gpt-fusion."""
 
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
 from .analysis import average_from_csv, load_numbers_from_csv, median_from_csv
 from .core import greet
-from .web_scraper import scrape
-from .backend import app as backend_app
-from .projects import PROJECTS, Project
-from .twitter_bot import TwitterBot
-from .twitch import TwitchClient
 from .utils import (
     ChatHistory,
     add_numbers,
@@ -24,6 +24,27 @@ from .text_utils import (
     word_count,
     count_characters,
 )
+
+_OPTIONAL_ATTRS: dict[str, tuple[str, str]] = {
+    "scrape": ("web_scraper", "scrape"),
+    "backend_app": ("backend", "app"),
+    "TwitterBot": ("twitter_bot", "TwitterBot"),
+    "TwitchClient": ("twitch", "TwitchClient"),
+    "Project": ("projects", "Project"),
+    "PROJECTS": ("projects", "PROJECTS"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import optional components."""
+    if name in _OPTIONAL_ATTRS:
+        module_name, attr_name = _OPTIONAL_ATTRS[name]
+        module = importlib.import_module(f".{module_name}", __name__)
+        value = getattr(module, attr_name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name}")
+
 
 __all__ = [
     "greet",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,15 @@
+import importlib
+
+
+def test_optional_modules_lazy_loaded():
+    import gpt_fusion
+
+    assert "scrape" not in gpt_fusion.__dict__
+    assert "TwitterBot" not in gpt_fusion.__dict__
+
+    _ = gpt_fusion.scrape
+    _ = gpt_fusion.TwitterBot
+
+    assert "scrape" in gpt_fusion.__dict__
+    assert "TwitterBot" in gpt_fusion.__dict__
+


### PR DESCRIPTION
## Summary
- avoid importing optional dependencies at package import time
- move requests and BeautifulSoup to a new `web` extra
- fix Node entry point
- document new optional extras
- add regression test for lazy imports

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e67108948321992736704a418b1c