### PR TITLE
fix: install Node dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
@@ -26,6 +29,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
+      - name: Install Node dependencies
+        run: npm ci
       - name: Set up pre-commit
         run: pre-commit install
       - name: Lint


### PR DESCRIPTION
## Summary
- fix GitHub Actions workflow so Node tooling is present
- install Node dependencies before running pre-commit

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873edfdda848321b8f8eb422d6589d4