### PR TITLE
fix: remove python 3.8 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # Tweepy requires Python 3.9+, so drop 3.8 from the matrix
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gpt-fusion
 [![CI Status](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg)](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml)
 [![Coverage Status](https://img.shields.io/coveralls/github/costasford/gpt-fusion?branch=main)](https://coveralls.io/github/costasford/gpt-fusion?branch=main)
-[![Python](https://img.shields.io/badge/python-3.8%2B-blue.svg)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/)
 [![License](https://img.shields.io/github/license/costasford/gpt-fusion)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/gpt-fusion.svg)](https://pypi.org/project/gpt-fusion/)
 

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -13,7 +13,7 @@ This page mirrors the instructions in [AGENTS.md](../AGENTS.md) for AI-based con
 
 ## Setup
 
-- Use Python 3.8 or newer.
+- Use Python 3.9 or newer.
 - Install development dependencies:
   ```bash
   pip install -r requirements-dev.txt

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -17,7 +17,7 @@ on the examples in the main README with step‑by‑step instructions.
 
 ## Setup
 
-Ensure Python&nbsp;3.8 or newer is installed and clone the repository:
+Ensure Python&nbsp;3.9 or newer is installed and clone the repository:
 
 ```bash
 git clone https://github.com/costasford/gpt-fusion.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Experimenting with human-AI collaboration"
 authors = [{name="Costas Ford", email="costasford@yahoo.com"}]
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = []
 
 [project.optional-dependencies]

--- a/tests/test_twitch.py
+++ b/tests/test_twitch.py
@@ -13,9 +13,12 @@ def mock_auth(mock_post: Mock) -> None:
 
 
 def test_get_top_games_returns_data():
-    with patch("requests.post") as mock_post, patch(
-        "requests.get",
-    ) as mock_get:
+    with (
+        patch("requests.post") as mock_post,
+        patch(
+            "requests.get",
+        ) as mock_get,
+    ):
         mock_auth(mock_post)
         get_response = Mock()
         get_response.json.return_value = {"data": [{"name": "Game"}]}

--- a/tests/test_twitter_bot.py
+++ b/tests/test_twitter_bot.py
@@ -6,9 +6,10 @@ from gpt_fusion.twitter_bot import TwitterBot
 
 
 def test_post_tweet_invokes_tweepy():
-    with patch("tweepy.OAuth1UserHandler") as mock_handler, patch(
-        "tweepy.API"
-    ) as mock_api:
+    with (
+        patch("tweepy.OAuth1UserHandler") as mock_handler,
+        patch("tweepy.API") as mock_api,
+    ):
         api_instance = mock_api.return_value
         bot = TwitterBot("k", "s", "t", "c")
         bot.post_tweet("hello")


### PR DESCRIPTION
## Summary
- update CI matrix to drop Python 3.8 since tweepy requires Python 3.9+
- clarify Python 3.9+ across docs and metadata

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `jekyll build -s docs -d docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_6873eefca95883218a264bf28bd4d2bd