### PR TITLE
fix: handle optional dependency tests

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,5 +1,12 @@
-from fastapi.testclient import TestClient
-from gpt_fusion.backend import app
+import pytest
+
+"""Backend tests that require FastAPI and httpx optional deps."""
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient  # noqa: E402
+from gpt_fusion.backend import app  # noqa: E402
 
 client = TestClient(app)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,3 +1,12 @@
+import pytest
+
+"""Test optional imports are lazy-loaded when deps installed."""
+
+pytest.importorskip("requests")
+pytest.importorskip("bs4")
+pytest.importorskip("tweepy")
+
+
 def test_optional_modules_lazy_loaded():
     import gpt_fusion
 

--- a/tests/test_twitch.py
+++ b/tests/test_twitch.py
@@ -1,8 +1,12 @@
 from unittest.mock import Mock, patch
 
+"""Twitch client tests requiring the requests library."""
+
 import pytest
 
-from gpt_fusion.twitch import TwitchClient
+pytest.importorskip("requests")
+
+from gpt_fusion.twitch import TwitchClient  # noqa: E402
 
 
 def mock_auth(mock_post: Mock) -> None:

--- a/tests/test_twitter_bot.py
+++ b/tests/test_twitter_bot.py
@@ -1,8 +1,12 @@
 from unittest.mock import patch
 
+"""Twitter bot tests that depend on Tweepy."""
+
 import pytest
 
-from gpt_fusion.twitter_bot import TwitterBot
+pytest.importorskip("tweepy")
+
+from gpt_fusion.twitter_bot import TwitterBot  # noqa: E402
 
 
 def test_post_tweet_invokes_tweepy():

--- a/tests/test_web_scraper.py
+++ b/tests/test_web_scraper.py
@@ -1,8 +1,15 @@
 from unittest.mock import Mock, patch
 
-import requests
+"""Web scraper tests requiring requests and BeautifulSoup."""
 
-from gpt_fusion.web_scraper import scrape
+import pytest
+
+pytest.importorskip("requests")
+pytest.importorskip("bs4")
+
+import requests  # noqa: E402
+
+from gpt_fusion.web_scraper import scrape  # noqa: E402
 
 
 def test_scrape_parses_text():


### PR DESCRIPTION
## Summary
- ensure optional dependency tests skip correctly without FastAPI, requests, bs4, or tweepy
- document dependency requirements in each test file

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873f52075c8832185cc54cba5f76d6f