### PR TITLE
feat: drop python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Tweepy requires Python 3.9+, so drop 3.8 from the matrix
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        # Tweepy requires Python 3.10+, so drop 3.9 from the matrix
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ docs/              # Jekyll-powered tutorials & demos
 
 ## 3. Coding Conventions
 
-* Use **Python 3.9+**
+* Use **Python 3.10+**
 * Adhere to **PEP8 formatting**
 * Comments required where logic is non-obvious
 * Use **pre-commit** for linting: `pre-commit run --all-files`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gpt-fusion
 [![CI Status](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg)](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml)
 [![Coverage Status](https://img.shields.io/coveralls/github/costasford/gpt-fusion?branch=main)](https://coveralls.io/github/costasford/gpt-fusion?branch=main)
-[![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
 [![License](https://img.shields.io/github/license/costasford/gpt-fusion)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/gpt-fusion.svg)](https://pypi.org/project/gpt-fusion/)
 

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -13,7 +13,7 @@ This page mirrors the instructions in [AGENTS.md](../AGENTS.md) for AI-based con
 
 ## Setup
 
-- Use Python 3.9 or newer.
+- Use Python 3.10 or newer.
 - Install development dependencies:
   ```bash
   pip install -r requirements-dev.txt

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -17,7 +17,7 @@ on the examples in the main README with step‑by‑step instructions.
 
 ## Setup
 
-Ensure Python&nbsp;3.9 or newer is installed and clone the repository:
+Ensure Python&nbsp;3.10 or newer is installed and clone the repository:
 
 ```bash
 git clone https://github.com/costasford/gpt-fusion.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Experimenting with human-AI collaboration"
 authors = [{name="Costas Ford", email="costasford@yahoo.com"}]
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = []
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- require Python 3.10+ in `pyproject.toml`
- update CI to test Python 3.10+ only
- bump version badge and docs to Python 3.10+

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `jekyll build -s docs -d docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_68740bb3f2348321b9f055715edaa215