### PR TITLE
docs: add contribution guide and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment:**
+- OS: [e.g. Ubuntu]
+- Python version: [e.g. 3.11]
+- Node version: [e.g. 18]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Summary
+Explain the motivation and context for this change.
+
+## Related Issues
+List any related issues or pull requests.
+
+## Checklist
+- [ ] `pre-commit` ran successfully
+- [ ] `pytest` passed
+- [ ] Documentation updated if needed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to foster an open and welcoming environment. All participants should be able to collaborate without harassment or discrimination.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints
+- Accepting constructive criticism gracefully
+
+Examples of unacceptable behavior by participants include:
+
+- Harassment or discriminatory jokes and language
+- Personal attacks or insulting comments
+- Public or private harassment
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying standards and enforcing this Code of Conduct fairly.
+
+## Scope
+
+This Code of Conduct applies within project spaces and in public spaces when an individual is representing the project or community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainers. All complaints will be reviewed and investigated.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,24 @@ We welcome contributions! To keep things tidy, please follow these guidelines.
 
 ## Coding standards
 
-- Format code using `black`.
-- Run `flake8` for linting.
-- Include unit tests with `pytest`.
+We follow standard Python conventions inspired by [PEP 8](https://peps.python.org/pep-0008/).
+
+- Format code with `black`.
+- Lint using `flake8`.
+- Run `pre-commit run --all-files` before committing.
+- Include unit tests with `pytest` for any new functionality.
+
+Commit messages should use the `feat:`, `fix:`, or `docs:` prefixes so GitHub
+Actions and reviewers can quickly understand the intent of the change.
 
 ## Pull requests
 
 - Keep PRs focused and reference related issues.
-- Ensure all tests pass with `pytest`.
-- We use GitHub Actions to verify builds automatically.
+- Run `pytest` locally and ensure all tests pass.
+- Verify that `pre-commit` checks succeed.
+- Update documentation when behavior changes.
+- PR titles should match the commit style noted above.
+- GitHub Actions will verify builds and linting automatically.
+
+See the [Code of Conduct](CODE_OF_CONDUCT.md) for expectations around respectful
+communication. Good discussions lead to better code!


### PR DESCRIPTION
## Summary
- expand contribution guidelines with commit style and pre-commit details
- add Contributor Covenant code of conduct
- add issue templates for bugs and features
- add pull request template

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687426e233d883219ce37e39ebda8f5b