### PR TITLE
feat: add SEO plugin and sitemap

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.2"
+gem "jekyll-seo-tag"
+gem "jekyll-sitemap"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,10 @@
 theme: jekyll-theme-cayman
 title: GPT Fusion
 description: Practical demos of human-AI collaboration
+url: "https://costasford.github.io"
+baseurl: "/gpt-fusion"
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap
 github:
   is_project_page: false

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,8 +1,20 @@
-<meta property="og:title" content="GPT Fusion" />
-<meta property="og:description" content="Practical demos of human-AI collaboration" />
-<meta property="og:image" content="/auth-ui-screenshot.png" />
-<meta property="og:type" content="website" />
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:image" content="/auth-ui-screenshot.png" />
-<meta name="twitter:title" content="GPT Fusion" />
-<meta name="twitter:description" content="Practical demos of human-AI collaboration" />
+<meta name="description" content="GPT Fusion Playground showcases human–AI collaboration demos and utilities." />
+<link rel="sitemap" type="application/xml" title="Sitemap" href="{{ '/sitemap.xml' | relative_url }}" />
+{% seo %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "GPT Fusion",
+  "url": "{{ site.url }}{{ site.baseurl }}",
+  "logo": "{{ '/auth-ui-screenshot.png' | absolute_url }}"
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "url": "{{ site.url }}{{ site.baseurl }}",
+  "name": "GPT Fusion Playground"
+}
+</script>


### PR DESCRIPTION
## Summary
- improve docs SEO metadata
- add Jekyll SEO plugin and sitemap support

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687427f72e108321a9c905c0143f39ab