### PR TITLE
feat: improve docs landing page design

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -129,3 +129,38 @@ h6:hover .anchor-link {
   margin: 0 auto;
 }
 
+.hero {
+  padding: 4rem 2rem;
+  text-align: center;
+  background: linear-gradient(135deg, $header-bg-color-secondary, $header-bg-color);
+  color: #fff;
+}
+
+.hero h1 {
+  font-size: 2.5rem;
+  margin-top: 0;
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.project-card {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.project-card img {
+  max-width: 100%;
+  border-radius: 4px;
+}
+
+.project-card h3 {
+  margin-top: 0;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,37 +6,46 @@ image: /auth-ui-screenshot.png
 
 {% include nav.html %}
 
-<div class="scroller">
-  <section>
-    <h1>GPT Fusion Playground</h1>
-    <p><strong>Practical demos of human-AI collaboration</strong></p>
-    <p><a href="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml"><img src="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg" alt="CI Status"></a></p>
-  </section>
-
-  <section>
-    <h2>Quickstart</h2>
-    <p>New to the repo? See the <a href="https://github.com/costasford/gpt-fusion#readme">main README</a> for setup details. In short, clone the project, run <code>pytest</code> to verify the Python utilities and then open the demos described below.</p>
-    <p>These small examples feed into one another. The Python helpers can power the login form or provide data for the Unity prototype. Throughout the docs you'll see how tests and tutorials tie the components together.</p>
-  </section>
-
-  <section>
-    <h2>Projects</h2>
-    <p>More information about each demo lives on the <a href="projects.md">Projects page</a>.</p>
-    <h3>Python utilities</h3>
-    <p>Reusable helpers for greetings, math, text processing and simple CSV analysis. The package also ships with a web scraper and optional Twitter and FastAPI extras. <a href="README.md">Read the docs</a>.</p>
-    <h3>Auth UI Kit</h3>
-    <p>Tailwind CSS login form using Firebase. Replace the config in <code>app.js</code> with your project credentials and serve the directory locally to try out email/password and Google sign in flows. The UI also includes sign-up and password reset dialogs for quick experimentation. <a href="https://github.com/costasford/gpt-fusion/tree/main/auth-ui-kit">View the demo</a>.</p>
-    <p><img src="/auth-ui-screenshot.png" alt="Auth UI screenshot"></p>
-    <h3>Unity prototype</h3>
-    <p>A small 3D demo showcasing simple movement and item pickups. Copy the <code>Assets</code> folder into a new Unity project (tested with Unity&nbsp;2021 or later) and run the scene to explore. <a href="https://github.com/costasford/gpt-fusion/tree/main/unity-prototype">Check the repo</a>.</p>
-    <h3>Tutorial</h3>
-    <p>Learn how to load sample data and compute averages. <a href="tutorial.md">Follow the tutorial</a>.</p>
-    <h3>Contribute</h3>
-    <p>Want to get involved? Read the <a href="contributing.md">contributing guide</a> to learn how we format code, lint, and run tests. The detailed rules used by Codex are listed on the <a href="guidelines.md">Guidelines page</a>.</p>
-    <p>For ongoing care of the project, consult the <a href="sustainability.md">Sustainability Guide</a> which covers dependency updates and general maintenance tips.</p>
-    <p>Enjoy fusing ideas with code!</p>
-  </section>
+<div class="hero">
+  <h1>GPT Fusion Playground</h1>
+  <p><strong>Practical demos of human-AI collaboration</strong></p>
+  <p><a href="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml"><img src="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg" alt="CI Status"></a></p>
 </div>
+
+<section>
+  <h2>Quickstart</h2>
+  <p>New to the repo? See the <a href="https://github.com/costasford/gpt-fusion#readme">main README</a> for setup details. In short, clone the project, run <code>pytest</code> to verify the Python utilities and then open the demos described below.</p>
+  <p>These small examples feed into one another. The Python helpers can power the login form or provide data for the Unity prototype. Throughout the docs you'll see how tests and tutorials tie the components together.</p>
+</section>
+
+<section>
+  <h2>Projects</h2>
+  <p>More information about each demo lives on the <a href="projects.md">Projects page</a>.</p>
+  <div class="projects-grid">
+    <div class="project-card">
+      <h3>Python utilities</h3>
+      <p>Reusable helpers for greetings, math, text processing and simple CSV analysis. The package also ships with a web scraper and optional Twitter and FastAPI extras. <a href="README.md">Read the docs</a>.</p>
+    </div>
+    <div class="project-card">
+      <h3>Auth UI Kit</h3>
+      <p>Tailwind CSS login form using Firebase. Replace the config in <code>app.js</code> with your project credentials and serve the directory locally to try out email/password and Google sign in flows.</p>
+      <p><a href="https://github.com/costasford/gpt-fusion/tree/main/auth-ui-kit">View the demo</a></p>
+      <img src="/auth-ui-screenshot.png" alt="Auth UI screenshot">
+    </div>
+    <div class="project-card">
+      <h3>Unity prototype</h3>
+      <p>A small 3D demo showcasing simple movement and item pickups. Copy the <code>Assets</code> folder into a new Unity project (tested with Unity&nbsp;2021 or later) and run the scene to explore. <a href="https://github.com/costasford/gpt-fusion/tree/main/unity-prototype">Check the repo</a>.</p>
+    </div>
+    <div class="project-card">
+      <h3>Tutorial</h3>
+      <p>Learn how to load sample data and compute averages. <a href="tutorial.md">Follow the tutorial</a>.</p>
+    </div>
+    <div class="project-card">
+      <h3>Contribute</h3>
+      <p>Want to get involved? Read the <a href="contributing.md">contributing guide</a> to learn how we format code, lint, and run tests. For ongoing care of the project, consult the <a href="sustainability.md">Sustainability Guide</a>.</p>
+    </div>
+  </div>
+</section>
 
 <script src="assets/js/external-links.js"></script>
 <script src="assets/js/anchor-links.js"></script>


### PR DESCRIPTION
## Summary
- redesign documentation homepage with a hero header and project cards
- add supporting styles for hero and grid layout

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68742805f5a083219dda1c7b824acf1c