### PR TITLE
feat: bundle docs scripts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -115,7 +115,4 @@ pull request.
 
 For ongoing maintenance tips, see the [Sustainability Guide](sustainability.md).
 
-<script src="assets/js/external-links.js"></script>
-
-<script src="assets/js/anchor-links.js"></script>
-<script src="assets/js/toc.js"></script>
+<script src="assets/js/bundle.js"></script>

--- a/docs/assets/js/bundle.js
+++ b/docs/assets/js/bundle.js
@@ -1,0 +1,71 @@
+// GENERATED: Combined utilities for docs pages
+// GitHub Pages serves files over HTTP/2 so multiple requests are multiplexed,
+// but bundling keeps asset counts low.
+
+// external-links.js
+document.addEventListener('DOMContentLoaded', () => {
+  const anchors = document.querySelectorAll('a[href]');
+
+  anchors.forEach((a) => {
+    const url = new URL(a.getAttribute('href'), window.location.href);
+
+    if (url.origin !== window.location.origin) {
+      if (!a.hasAttribute('target')) {
+        a.setAttribute('target', '_blank');
+      }
+
+      const rel = a.getAttribute('rel') || '';
+      if (!rel.includes('noopener')) {
+        a.setAttribute('rel', rel ? `${rel} noopener` : 'noopener');
+      }
+    }
+  });
+});
+
+// anchor-links.js
+document.addEventListener('DOMContentLoaded', () => {
+  const headings = document.querySelectorAll('h2, h3, h4, h5, h6');
+  headings.forEach((h) => {
+    if (!h.id) {
+      const slug = h.textContent
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+      h.id = slug;
+    }
+
+    const link = document.createElement('a');
+    link.className = 'anchor-link';
+    link.href = `#${h.id}`;
+    link.textContent = '🔗';
+    h.appendChild(link);
+  });
+});
+
+// toc.js
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('toc');
+  if (!container) return;
+
+  const headings = document.querySelectorAll('h2, h3');
+  if (!headings.length) return;
+
+  const list = document.createElement('ul');
+  container.appendChild(list);
+
+  headings.forEach((h) => {
+    if (!h.id) {
+      const slug = h.textContent
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+      h.id = slug;
+    }
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = `#${h.id}`;
+    a.textContent = h.textContent;
+    li.appendChild(a);
+    list.appendChild(li);
+  });
+});

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,6 +34,4 @@ Keep changes focused and document your intent. Passing tests and clean linting
 are required before a PR is merged. Summaries should explain the high level goal
 and mention the commands you ran.
 
-<script src="assets/js/external-links.js"></script>
-<script src="assets/js/anchor-links.js"></script>
-<script src="assets/js/toc.js"></script>
+<script src="assets/js/bundle.js"></script>

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -50,4 +50,9 @@ This page mirrors the instructions in [AGENTS.md](../AGENTS.md) for AI-based con
 - Expand the test suite for new functionality.
 - Write helpful commit messages and PR summaries explaining the intent of your changes.
 
+## Website performance
+
+- Combine and bundle CSS and JS assets. The docs use `assets/js/bundle.js` so only one script is loaded.
+- GitHub Pages serves files over HTTP/2, allowing multiple requests to multiplex efficiently.
+
 If this page diverges from [AGENTS.md](../AGENTS.md), please update both files so the instructions stay consistent.

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,5 +47,4 @@ image: /auth-ui-screenshot.png
   </div>
 </section>
 
-<script src="assets/js/external-links.js"></script>
-<script src="assets/js/anchor-links.js"></script>
+<script src="assets/js/bundle.js"></script>

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -37,6 +37,4 @@ Walk through loading the sample dataset and computing averages in [tutorial.md](
 
 For development instructions see the [Guidelines](guidelines.md).
 
-<script src="assets/js/external-links.js"></script>
-<script src="assets/js/anchor-links.js"></script>
-<script src="assets/js/toc.js"></script>
+<script src="assets/js/bundle.js"></script>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -98,6 +98,4 @@ history.add_message("How can I help?")
 print(history.messages)
 ```
 
-<script src="assets/js/external-links.js"></script>
-<script src="assets/js/anchor-links.js"></script>
-<script src="assets/js/toc.js"></script>
+<script src="assets/js/bundle.js"></script>


### PR DESCRIPTION
## Summary
- bundle docs scripts into a single file
- update pages to load `assets/js/bundle.js`
- mention bundling and HTTP/2 in guidelines

## Testing
- `pre-commit run --all-files`
- `jekyll build -s docs -d /tmp/docs_build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68742cf9249883218e45d94b083f294e