### PR TITLE
docs: add lazy loading for screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ You can also preview the auth UI demo by serving the `auth-ui-kit` folder:
 python -m http.server --directory auth-ui-kit
 ```
 
-![Auth UI screenshot](auth-ui-screenshot.png)
+<img src="auth-ui-screenshot.png" alt="Auth UI screenshot" loading="lazy">
+
+_Tip: convert screenshots to WebP for a smaller footprint._
 
 ## Project layout
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ image: /auth-ui-screenshot.png
 <div class="hero">
   <h1>GPT Fusion Playground</h1>
   <p><strong>Practical demos of human-AI collaboration</strong></p>
-  <p><a href="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml"><img src="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg" alt="CI Status"></a></p>
+  <p><a href="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml"><img src="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg" alt="CI Status" loading="lazy"></a></p>
 </div>
 
 <section>
@@ -30,7 +30,7 @@ image: /auth-ui-screenshot.png
       <h3>Auth UI Kit</h3>
       <p>Tailwind CSS login form using Firebase. Replace the config in <code>app.js</code> with your project credentials and serve the directory locally to try out email/password and Google sign in flows.</p>
       <p><a href="https://github.com/costasford/gpt-fusion/tree/main/auth-ui-kit">View the demo</a></p>
-      <img src="/auth-ui-screenshot.png" alt="Auth UI screenshot">
+      <img src="/auth-ui-screenshot.png" alt="Auth UI screenshot" loading="lazy">
     </div>
     <div class="project-card">
       <h3>Unity prototype</h3>


### PR DESCRIPTION
## Summary
- lazily load images for faster page render
- recommend converting screenshots to WebP

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68742cfedf108321b87c7adf3f879150