### PR TITLE
docs: add CDN and caching note

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,6 +102,12 @@ The documentation is built with [Jekyll](https://jekyllrb.com/). After
 installing the Jekyll gem, run `jekyll serve` from this folder and open
 <http://localhost:4000> in your browser.
 
+### Deploying to GitHub Pages
+
+GitHub Pages serves these files from a global CDN so delivery is fast worldwide.
+If you need custom caching behaviour, create a `_headers` file in this
+`docs/` directory and specify `Cache-Control` rules as required.
+
 ## Further reading
 
 See [tutorial.md](tutorial.md) for a walkthrough on loading the sample dataset

--- a/docs/_headers
+++ b/docs/_headers
@@ -1,0 +1,4 @@
+# Example caching rules for GitHub Pages
+# Adjust max-age values to control how long assets are cached
+/assets/*
+  Cache-Control: public, max-age=3600


### PR DESCRIPTION
## Summary
- mention GitHub Pages CDN in the docs
- add `_headers` example for cache-control rules

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68742d053dfc83219be3516619bbdda8