### PR TITLE
fix: ensure pre-commit compliance

### DIFF
--- a/src/gpt_fusion/build_utils.py
+++ b/src/gpt_fusion/build_utils.py
@@ -31,7 +31,9 @@ def minify_dir(src_dir: str | Path, dst_dir: str | Path) -> None:
         target.parent.mkdir(parents=True, exist_ok=True)
         text: str | bytes
         if file.suffix.lower() in {".html", ".htm"}:
-            text = htmlmin.minify(file.read_text(encoding="utf-8"), remove_comments=True)
+            text = htmlmin.minify(
+                file.read_text(encoding="utf-8"), remove_comments=True
+            )
             target.write_text(text, encoding="utf-8")
         elif file.suffix.lower() == ".css":
             text = compress(file.read_text(encoding="utf-8"))

--- a/tests/test_build_utils.py
+++ b/tests/test_build_utils.py
@@ -1,5 +1,4 @@
 import gzip
-from pathlib import Path
 
 from gpt_fusion.build_utils import minify_dir
 


### PR DESCRIPTION
## Summary
- ensure files pass format/lint hooks

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `jekyll build -s docs -d docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_68742fe117c48321b4f8714f9956633f