### PR TITLE
feat: raise explicit error for missing CSV

### DIFF
--- a/src/gpt_fusion/analysis.py
+++ b/src/gpt_fusion/analysis.py
@@ -7,6 +7,9 @@ from statistics import mean, median
 
 def load_numbers_from_csv(path: str | Path) -> list[float]:
     """Load numbers from a CSV file with a ``value`` column."""
+    path = Path(path)
+    if not path.is_file():
+        raise FileNotFoundError(f"CSV file not found: {path}")
     with open(path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         values: list[float] = []

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import pytest
 
 from gpt_fusion.analysis import (
     average_from_csv,
@@ -27,3 +28,9 @@ def test_load_numbers_from_csv_skips_invalid(tmp_path):
     csv_path.write_text("value\n1\ninvalid\n2\n\n3\n", encoding="utf-8")
 
     assert load_numbers_from_csv(csv_path) == [1.0, 2.0, 3.0]
+
+
+def test_load_numbers_from_csv_missing_file(tmp_path):
+    missing_path = tmp_path / "nope.csv"
+    with pytest.raises(FileNotFoundError):
+        load_numbers_from_csv(missing_path)


### PR DESCRIPTION
## Summary
- raise a `FileNotFoundError` in `load_numbers_from_csv` when the CSV path doesn't exist
- test the missing file case in `test_analysis.py`

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687431b963748321a553155c1662d207