### PR TITLE
docs: add embedded previews to projects

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -11,7 +11,7 @@ title: Projects
 
 # Projects
 
-The repository hosts a few small demos showcasing different aspects of human‑AI collaboration. This page summarises each component and links to further details. The optional API server exposes these entries at the `/projects` route so you can fetch them programmatically.
+The repository hosts a few small demos showcasing different aspects of human‑AI collaboration. This page summarises each component and links to further details. The optional API server exposes these entries at the `/projects` route so you can fetch them programmatically. To make things easier for newcomers following along at events like Codemotion, the sections below embed live previews or short recordings wherever possible.
 
 ## Python utilities
 
@@ -21,15 +21,38 @@ The `gpt_fusion` package bundles greeting helpers, math functions, text utilitie
 
 A Tailwind‑styled login form powered by Firebase. Update `auth-ui-kit/app.js` with your project credentials and serve the folder locally to experiment with email/password and Google sign in flows.
 
+<div class="preview">
+  <iframe src="https://codesandbox.io/embed/github/costasford/gpt-fusion/tree/main/auth-ui-kit?fontsize=14&hidenavigation=1"
+          style="width:100%; height:500px; border:0; border-radius:4px; overflow:hidden;"
+          title="Auth UI live preview"
+          allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+          sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts">
+  </iframe>
+</div>
+
 ## Unity prototype
 
 A basic 3D scene demonstrating player movement, item pickups and simple enemy AI. Copy the `Assets` directory from `unity-prototype/` into a new Unity project (Unity 2021 or later).
+
+<div class="preview">
+  <iframe src="https://play.unity.com/mg/other/unity-webgl" width="640" height="360" allowfullscreen loading="lazy" title="Unity WebGL demo"></iframe>
+</div>
 
 ## Top Viewer Games
 
 Live view of the most popular Twitch channels and games. Configure your Twitch
 client credentials and run `viewer.py` from the `top-viewer-games` folder to see
 current statistics.
+
+```text
+Top Games:
+Fortnite - 33214
+Just Chatting - 22190
+
+Top Streams:
+Streamer123 playing Fortnite with 20000 viewers
+StreamerABC playing Just Chatting with 15000 viewers
+```
 
 ## Tutorial
 


### PR DESCRIPTION
## Summary
- link to live CodeSandbox demo for the Auth UI kit
- embed a Unity WebGL iframe for the Unity demo
- show sample output of the CLI Twitch viewer
- mention Codemotion newcomers in project overview

## Testing
- `pre-commit run --files docs/projects.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68743a9e69408321934a09a55770d787