### PR TITLE
feat: add local workflow automation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ jekyll serve
 
 and open <http://localhost:4000> to browse the tutorials.
 
+## Local workflow automation
+
+Run the helper script to replicate the CI checks locally:
+
+```bash
+python scripts/run_checks.py
+```
+
+The script formats the code, runs the tests, and builds the documentation.
+
 ## Contributing
 
 Development guidelines are recorded in [AGENTS.md](AGENTS.md).

--- a/scripts/run_checks.py
+++ b/scripts/run_checks.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# GENERATED - DO NOT EDIT DIRECTLY
+"""Run formatting, tests, and docs build like the CI workflow."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(cmd: str) -> None:
+    """Execute *cmd* and exit on failure."""
+    print(f"--> {cmd}")
+    result = subprocess.run(cmd, shell=True)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+def main() -> None:
+    project_root = Path(__file__).resolve().parent.parent
+    run("pre-commit run --all-files")
+    run("pytest -q")
+    docs_dir = project_root / "docs"
+    if docs_dir.is_dir():
+        run("jekyll build -s docs -d docs/_site")
+    print("All checks passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/run_checks.py` for running local CI steps
- document usage of the automation script in the README

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `jekyll build -s docs -d docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_687445ea155883219032b95f9078d965