### PR TITLE
[Feat] docs performance tweaks

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,3 +16,4 @@ docsearch:
   appId: "REPLACE_WITH_APP_ID"
   apiKey: "REPLACE_WITH_API_KEY"
   indexName: "gpt-fusion"
+

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -52,7 +52,8 @@ This page mirrors the instructions in [AGENTS.md](../AGENTS.md) for AI-based con
 
 ## Website performance
 
-- Combine and bundle CSS and JS assets. The docs use `assets/js/bundle.js` so only one script is loaded.
-- GitHub Pages serves files over HTTP/2, allowing multiple requests to multiplex efficiently.
+- Combine and bundle CSS and JS assets. The docs use `assets/js/bundle.js` so only one script is loaded. Files are minified after `jekyll build` using `gpt_fusion.build_utils`.
+- GitHub Pages serves files over HTTP/2, allowing multiple requests to multiplex efficiently, but bundling still reduces the total request count.
+- The Plausible Analytics script remains deferred and weighs about 1 kB, so it has minimal impact on page load.
 
 If this page diverges from [AGENTS.md](../AGENTS.md), please update both files to keep the instructions consistent.

--- a/scripts/run_checks.py
+++ b/scripts/run_checks.py
@@ -24,6 +24,9 @@ def main() -> None:
     docs_dir = project_root / "docs"
     if docs_dir.is_dir():
         run("jekyll build -s docs -d docs/_site")
+        run("PYTHONPATH=src python -m gpt_fusion.build_utils docs/_site docs/_site_tmp")
+        run("rm -rf docs/_site")
+        run("mv docs/_site_tmp docs/_site")
     print("All checks passed.")
 
 


### PR DESCRIPTION
### Why
Optimize documentation site build so assets are compressed after Jekyll output. This reduces file size and leverages HTTP/2 more effectively.

### How
- updated `run_checks.py` to run `gpt_fusion.build_utils` after `jekyll build`
- noted bundling/minification in `guidelines.md`
- kept docs config minimal

### Tests
`python scripts/run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_68757f40439c83219cf9fd106b96fd5a