### PR TITLE
[Feat] add notebook example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,7 @@
 # Example Scripts
+<!-- plan: mention new notebook for interactive demo -->
 
 This folder contains small Python scripts demonstrating how to use the
 `gpt_fusion` package. Run them with `python <script>` from the project root.
+
+For a quick interactive check inside VS Code, open `hello_world.ipynb`.

--- a/examples/hello_world.ipynb
+++ b/examples/hello_world.ipynb
@@ -1,0 +1,23 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run this snippet to verify the package:\n",
+    "```python\n",
+    "import gpt_fusion.math_helpers\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  },
+  "plan": "1. Add minimal hello-world notebook. 2. Contains single Markdown cell showing how to import math helpers."
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Why
Add a simple Jupyter notebook so users can try the package inside VS Code.

### How
- new `hello_world.ipynb` under examples/
- mention the notebook in the examples README

### Tests
`37 passed, 1 warning in 0.64s`

### Screenshots / GIFs
N/A

### Checklist
- [x] I ran `scripts/run_checks.py`
- [ ] I updated docs where needed
- [ ] I asked for review from @costasford

------
https://chatgpt.com/codex/tasks/task_e_687582b4a4848321a3017f6f7271a4ea