### PR TITLE
[Feat] deploy docs to gh-pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,26 @@ jobs:
       - name: Build documentation
         run: jekyll build -s docs -d docs/_site
 
+  docs:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+      - name: Install Ruby gems
+        run: |
+          gem install jekyll jekyll-theme-cayman jekyll-seo-tag jekyll-sitemap --no-document
+      - name: Build documentation
+        run: jekyll build -s docs -d docs/_site
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: docs/_site
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,7 @@ installing the Jekyll gem, run `jekyll serve` from this folder and open
 ### Deploying to GitHub Pages
 
 GitHub Pages serves these files from a global CDN so delivery is fast worldwide.
+The docs site is automatically published to the gh-pages branch after each merge to main.
 If you need custom caching behaviour, create a `_headers` file in this
 `docs/` directory and specify `Cache-Control` rules as required.
 


### PR DESCRIPTION
### Why
GitHub Pages should refresh automatically after merging to `main`.

### How
- added a `docs` job in CI that builds and deploys `docs/_site` to `gh-pages`
- documented the auto deploy behaviour

### Tests
`37 passed, 1 warning in 0.42s`

### Screenshots / GIFs
N/A

### Checklist
- [x] I ran `scripts/run_checks.py`
- [x] I updated docs where needed
- [ ] I asked for review from @costasford

------
https://chatgpt.com/codex/tasks/task_e_6875849ff1988321893f96988c0dc377