### PR TITLE
[Feat] Add FastAPI playground docs

### DIFF
--- a/docs/api-playground.md
+++ b/docs/api-playground.md
@@ -1,0 +1,45 @@
+---
+layout: default
+title: API Playground
+---
+<!--
+Plan:
+1. Provide instructions to deploy the FastAPI backend on Render or Heroku.
+2. Mention running `uvicorn gpt_fusion.backend:app` locally as well.
+3. Highlight the ReDoc docs available at /redoc for interactive testing.
+-->
+
+{% include nav.html %}
+
+# API Playground
+
+The project ships with a minimal FastAPI server defined in `gpt_fusion.backend`. You can run it locally or deploy it to a free hosting service for a live demo.
+
+## Local preview
+
+Install the optional backend extras and start the server:
+
+```bash
+pip install "gpt-fusion[backend]"
+uvicorn gpt_fusion.backend:app
+```
+
+Open <http://localhost:8000/redoc> to explore the auto-generated ReDoc docs and call the endpoints.
+
+## Deploying to Render
+
+1. Create a new **Web Service** from your GitHub repo.
+2. Set the build command to `pip install "gpt-fusion[backend]"`.
+3. Use `uvicorn gpt_fusion.backend:app --host 0.0.0.0 --port $PORT` as the start command.
+4. After the service spins up, visit `<service-url>/redoc` to try the API in your browser.
+
+## Deploying to Heroku
+
+1. Create a Python app and add a `Procfile` containing:
+   ```
+   web: uvicorn gpt_fusion.backend:app --host 0.0.0.0 --port $PORT
+   ```
+2. Install the backend extras with `pip install "gpt-fusion[backend]"` during the build step.
+3. Once deployed, navigate to `<heroku-app-url>/redoc` for the interactive documentation.
+
+<script src="assets/js/bundle.js"></script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,10 @@ Median: 3.0</code></pre>
       </div>
     </div>
     <div class="project-card">
+      <h3>API Playground</h3>
+      <p>Deploy the FastAPI sandbox on Render or Heroku and use <a href="api-playground.md">ReDoc</a> to test the endpoints.</p>
+    </div>
+    <div class="project-card">
       <h3>Tutorial</h3>
       <p>Learn how to load sample data and compute averages. <a href="tutorial.md">Follow the tutorial</a>.</p>
       <pre><code>$ python examples/tutorial.py

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -66,6 +66,10 @@ Top Streams:
 Streamer123 playing Fortnite with 20000 viewers
 StreamerABC playing Just Chatting with 15000 viewers
 ```
+## API Playground
+
+Host the FastAPI demo on Render or Heroku and open `/redoc` to experiment with the endpoints. See [api-playground.md](api-playground.md) for setup steps.
+
 
 ## Tutorial
 


### PR DESCRIPTION
### Why
Provide instructions for running the API server online so visitors can test endpoints.

### How
- Added `docs/api-playground.md` with deployment steps for Render and Heroku
- Linked the new page from the home page and projects overview

### Tests
`37 passed, 1 warning in 0.87s`

### Screenshots / GIFs
N/A

### Checklist
- [x] I ran `scripts/run_checks.py`
- [x] I updated docs where needed
- [ ] I asked for review from @costasford

------
https://chatgpt.com/codex/tasks/task_e_687586858d9483218b8658d9288cabce