### PR TITLE
[Feat] Add Unity WebGL demo page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,9 +51,9 @@ Median: 3.0</code></pre>
     </div>
     <div class="project-card">
       <h3>Unity prototype</h3>
-      <p>A small 3D demo showcasing simple movement and item pickups. Copy the <code>Assets</code> folder into a new Unity project (tested with Unity&nbsp;2021 or later) and run the scene to explore. <a href="https://github.com/costasford/gpt-fusion/tree/main/unity-prototype">View the repository</a>.</p>
+      <p>A small 3D demo showcasing simple movement and item pickups. Copy the <code>Assets</code> folder into a new Unity project (tested with Unity&nbsp;2021 or later) and run the scene to explore. <a href="https://github.com/costasford/gpt-fusion/tree/main/unity-prototype">View the repository</a>. You can also <a href="unity-demo/">play the WebGL build</a>.</p>
       <div class="preview">
-        <iframe src="https://play.unity.com/mg/other/unity-webgl" width="100%" height="180" allowfullscreen loading="lazy" title="Unity preview"></iframe>
+        <iframe src="unity-demo/" width="100%" height="180" allowfullscreen loading="lazy" title="Unity preview"></iframe>
       </div>
     </div>
     <div class="project-card">

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -45,10 +45,10 @@ A Tailwind‑styled login form powered by Firebase. Update `auth-ui-kit/app.js` 
 
 ## Unity prototype
 
-A basic 3D scene demonstrating player movement, item pickups and simple enemy AI. Copy the `Assets` directory from `unity-prototype/` into a new Unity project (Unity 2021 or later).
+A basic 3D scene demonstrating player movement, item pickups and simple enemy AI. Copy the `Assets` directory from `unity-prototype/` into a new Unity project (Unity 2021 or later). The build can be exported for WebGL and placed under `docs/unity-demo`.
 
 <div class="preview">
-  <iframe src="https://play.unity.com/mg/other/unity-webgl" width="640" height="360" allowfullscreen loading="lazy" title="Unity WebGL demo"></iframe>
+  <iframe src="unity-demo/" width="640" height="360" allowfullscreen loading="lazy" title="Unity WebGL demo"></iframe>
 </div>
 
 ## Top Viewer Games

--- a/docs/unity-demo/index.md
+++ b/docs/unity-demo/index.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Unity Prototype WebGL
+---
+
+This page hosts a playable build of the Unity prototype. To generate the WebGL build yourself:
+
+1. Open the `unity-prototype` folder with Unity&nbsp;2021 or newer.
+2. Choose **File → Build Settings...** and switch the target to **WebGL**.
+3. Click **Build** and select `docs/unity-demo` as the output directory.
+4. Commit the generated files to publish the demo on GitHub Pages.
+
+For now the demo below loads the same scene from an external host.
+
+<div class="preview">
+  <iframe src="https://play.unity.com/mg/other/unity-webgl" width="960" height="540" allowfullscreen loading="lazy" title="Unity WebGL demo"></iframe>
+</div>


### PR DESCRIPTION
### Why
Add a placeholder for hosting the Unity prototype as a WebGL build so visitors can play it directly from the docs site.

### How
- created `docs/unity-demo/index.md` with instructions and embedded external build
- linked this page from project listings

### Tests
```
$ python scripts/run_checks.py
All checks passed.
```

### Screenshots / GIFs
N/A

### Checklist
- [x] I ran `scripts/run_checks.py`
- [ ] I updated docs where needed
- [ ] I asked for review from @costasford

------
https://chatgpt.com/codex/tasks/task_e_6875868ed54c8321b7ff35e75f505dcf