### PR TITLE
[Feat] Add starter kit generator utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ python -m http.server --directory auth-ui-kit
 
 _Tip: convert screenshots to WebP for a smaller footprint._
 
+## Starter kit templates
+
+Use the cookie-cutter helpers to spin up small demos:
+
+```bash
+python -m gpt_fusion.starter_kits create_csv_app my-csv-demo
+python -m gpt_fusion.starter_kits create_tailwind_ui my-ui-demo
+```
+
+Each command copies a minimal project into the given folder so you can start
+your own AI adventure right away.
+
 ## Project layout
 
 ```

--- a/src/gpt_fusion/__init__.py
+++ b/src/gpt_fusion/__init__.py
@@ -8,6 +8,7 @@ from typing import Any
 from .analysis import average_from_csv, load_numbers_from_csv, median_from_csv
 from .core import greet
 from .build_utils import minify_dir
+from .starter_kits import create_csv_app, create_tailwind_ui
 from .utils import (
     ChatHistory,
     add_numbers,
@@ -72,4 +73,6 @@ __all__ = [
     "backend_app",
     "Project",
     "PROJECTS",
+    "create_csv_app",
+    "create_tailwind_ui",
 ]

--- a/src/gpt_fusion/starter_kits.py
+++ b/src/gpt_fusion/starter_kits.py
@@ -1,0 +1,55 @@
+# Plan: provide simple cookie-cutter helpers for demo apps.
+# 1. create_csv_app() copies the tutorial script and sample data into a
+#    destination folder, renaming the script to app.py.
+# 2. create_tailwind_ui() copies the auth-ui-kit directory to the
+#    destination folder.
+# 3. Both functions return the path to the created directory.
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+
+
+def create_csv_app(dst: str | Path) -> Path:
+    """Create a minimal CSV demo in *dst* and return the path."""
+    dst_path = Path(dst)
+    dst_path.mkdir(parents=True, exist_ok=True)
+    root = Path(__file__).resolve().parents[2]
+    shutil.copy2(root / "examples" / "tutorial.py", dst_path / "app.py")
+    shutil.copy2(root / "data" / "numbers.csv", dst_path / "numbers.csv")
+    return dst_path
+
+
+def create_tailwind_ui(dst: str | Path) -> Path:
+    """Copy the Tailwind auth demo into *dst* and return the path."""
+    dst_path = Path(dst)
+    src = Path(__file__).resolve().parents[2] / "auth-ui-kit"
+    shutil.copytree(src, dst_path, dirs_exist_ok=True)
+    return dst_path
+
+
+__all__ = ["create_csv_app", "create_tailwind_ui"]
+
+
+def _main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate starter kit demos")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    csv_p = sub.add_parser("create_csv_app", help="Create the CSV demo")
+    csv_p.add_argument("dest")
+
+    ui_p = sub.add_parser("create_tailwind_ui", help="Create the Tailwind demo")
+    ui_p.add_argument("dest")
+
+    args = parser.parse_args()
+    if args.cmd == "create_csv_app":
+        create_csv_app(args.dest)
+    else:
+        create_tailwind_ui(args.dest)
+
+
+if __name__ == "__main__":
+    _main()

--- a/tests/test_starter_kits.py
+++ b/tests/test_starter_kits.py
@@ -1,0 +1,13 @@
+from gpt_fusion.starter_kits import create_csv_app, create_tailwind_ui
+
+
+def test_create_csv_app(tmp_path):
+    dst = create_csv_app(tmp_path)
+    assert (dst / "app.py").is_file()
+    assert (dst / "numbers.csv").is_file()
+
+
+def test_create_tailwind_ui(tmp_path):
+    dst = create_tailwind_ui(tmp_path)
+    assert (dst / "index.html").is_file()
+    assert (dst / "app.js").is_file()


### PR DESCRIPTION
### Why
Provide simple scripts that let users spin up a CSV demo or Tailwind UI demo. This helps newcomers explore the repository as a "choose your own AI adventure".

### How
- added `starter_kits.py` with `create_csv_app` and `create_tailwind_ui`
- exported functions in `__init__`
- documented usage in README
- added unit tests

### Tests
```
39 passed, 1 warning in 0.43s
```

### Screenshots / GIFs
N/A

### Checklist
- [x] I ran `scripts/run_checks.py`
- [x] I updated docs where needed
- [ ] I asked for review from @costasford

------
https://chatgpt.com/codex/tasks/task_e_687586927c588321b0d89199fa6a1aab