### PR TITLE
[Feat] update coverage badge

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+# Plan: configure Codecov thresholds and disable PR comments
+codecov:
+  require_ci_to_pass: yes
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+    patch: off
+comment: false

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 <!-- Plan:
 1. Document marketing site integration.
 2. Mention PyPI installation for the new alpha release.
+3. Update coverage badge to Codecov.
 -->
 [![CI Status](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg)](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/costasford/gpt-fusion/branch/main/graph/badge.svg)](https://codecov.io/gh/costasford/gpt-fusion)
+[![codecov](https://app.codecov.io/gh/costasford/gpt-fusion/branch/main/graph/badge.svg)](https://codecov.io/gh/costasford/gpt-fusion)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
 [![License](https://img.shields.io/github/license/costasford/gpt-fusion)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/gpt-fusion.svg)](https://pypi.org/project/gpt-fusion/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Plan:
 2. Use preformatted blocks for CLI output and an iframe for the Unity preview.
 3. Keep markup lightweight so existing CSS continues to work.
 4. Link to pip install instructions.
+5. Update coverage badge to Codecov.
 -->
 
 {% include nav.html %}
@@ -18,7 +19,7 @@ Plan:
   <p><strong>Practical demos of human-AI collaboration</strong></p>
   <p>
     <a href="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml"><img src="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg" alt="CI Status" loading="lazy"></a>
-    <a href="https://codecov.io/gh/costasford/gpt-fusion"><img src="https://codecov.io/gh/costasford/gpt-fusion/branch/main/graph/badge.svg" alt="Coverage Status" loading="lazy"></a>
+    <a href="https://codecov.io/gh/costasford/gpt-fusion"><img src="https://app.codecov.io/gh/costasford/gpt-fusion/branch/main/graph/badge.svg" alt="Coverage Status" loading="lazy"></a>
     <a href="https://pypi.org/project/gpt-fusion/"><img src="https://img.shields.io/pypi/dm/gpt-fusion.svg" alt="PyPI Downloads" loading="lazy"></a>
     <a href="https://github.com/costasford/gpt-fusion/blob/main/LICENSE"><img src="https://img.shields.io/github/license/costasford/gpt-fusion" alt="License" loading="lazy"></a>
   </p>


### PR DESCRIPTION
### Why
Coverage reporting is active in CI and local checks but there was no Codecov configuration or documentation mentioning it.

### How
- added `.codecov.yml` with minimal config
- pointed badges in README and docs to Codecov's `app` domain
- noted the change in the page comments

### Tests
```
37 passed, 1 warning in 0.56s
```

### Screenshots / GIFs
N/A

### Checklist
- [x] I ran `scripts/run_checks.py`
- [x] I updated docs where needed
- [ ] I asked for review from @costasford

------
https://chatgpt.com/codex/tasks/task_e_687586afd3e88321a7ec29d0a7256f18