### PR TITLE
[Feat] live greet endpoint and docs playground

### DIFF
--- a/docs/assets/js/bundle.js
+++ b/docs/assets/js/bundle.js
@@ -69,3 +69,22 @@ document.addEventListener('DOMContentLoaded', () => {
     list.appendChild(li);
   });
 });
+document.addEventListener('DOMContentLoaded', () => {
+  const button = document.getElementById('greet-btn');
+  const output = document.getElementById('greet-output');
+  if (!button || !output) return;
+
+  button.addEventListener('click', async () => {
+    const input = document.getElementById('name-input');
+    const name = input ? input.value.trim() || 'Fusion' : 'Fusion';
+    const apiBase = window.API_BASE || 'https://gpt-fusion-demo.fly.dev';
+    try {
+      const res = await fetch(`${apiBase}/greet/${encodeURIComponent(name)}`);
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      output.textContent = data.message;
+    } catch {
+      output.textContent = 'Request failed';
+    }
+  });
+});

--- a/docs/assets/js/playground.js
+++ b/docs/assets/js/playground.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const button = document.getElementById('greet-btn');
+  const output = document.getElementById('greet-output');
+  if (!button || !output) return;
+
+  button.addEventListener('click', async () => {
+    const input = document.getElementById('name-input');
+    const name = input ? input.value.trim() || 'Fusion' : 'Fusion';
+    const apiBase = window.API_BASE || 'https://gpt-fusion-demo.fly.dev';
+    try {
+      const res = await fetch(`${apiBase}/greet/${encodeURIComponent(name)}`);
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      output.textContent = data.message;
+    } catch {
+      output.textContent = 'Request failed';
+    }
+  });
+});

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -105,4 +105,14 @@ history.add_message("How can I help?")
 print(history.messages)
 ```
 
+### Live API demo
+
+Type a name and call the `/greet` endpoint without leaving the page:
+
+<div id="playground">
+  <input id="name-input" type="text" value="Fusion" aria-label="Name">
+  <button id="greet-btn">Greet</button>
+  <pre id="greet-output"></pre>
+</div>
+
 <script src="assets/js/bundle.js"></script>

--- a/src/gpt_fusion/backend.py
+++ b/src/gpt_fusion/backend.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 
 from .projects import PROJECTS, Project
+from .core import greet
 
 app = FastAPI()
 
@@ -31,3 +32,9 @@ def get_profile(uid: str) -> Profile:
 def list_projects() -> list[Project]:
     """Return the sample projects bundled with the repo."""
     return PROJECTS
+
+
+@app.get("/greet/{name}")
+def greet_user(name: str) -> dict[str, str]:
+    """Return a greeting for *name* using :func:`greet`."""
+    return {"message": greet(name)}

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -28,3 +28,9 @@ def test_list_projects():
     assert response.status_code == 200
     data = response.json()
     assert any(p["id"] == "auth-ui-kit" for p in data)
+
+
+def test_greet_user():
+    response = client.get("/greet/Fusion")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello, Fusion! Welcome to gpt-fusion."}


### PR DESCRIPTION
### Why
Enable visitors to try the FastAPI backend directly from the tutorial.

### How
- Added `/greet/{name}` route in `backend.py`.
- Created `playground.js` and appended it to docs bundle.
- Embedded a new "Live API demo" section in `tutorial.md`.
- Added unit test for the new endpoint.

### Tests
```
40 passed, 1 warning in 0.88s
```

### Checklist
- [x] I ran `scripts/run_checks.py`
- [x] I updated docs where needed
- [ ] I asked for review from @costasford

------
https://chatgpt.com/codex/tasks/task_e_68758e7242848321b3376fad49a73528