### PR TITLE
[Feat] add dark mode variants

### DIFF
--- a/auth-ui-kit/index.html
+++ b/auth-ui-kit/index.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!--
+Plan:
+1. Add dark mode classes to respect prefers-color-scheme.
+2. Include an accessible Beta badge using high-contrast colors.
+-->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -9,25 +14,27 @@
   <script type="module" src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js"></script>
   <script type="module" src="app.js"></script>
 </head>
-<body class="bg-gray-100 flex items-center justify-center h-screen">
-  <main class="bg-white p-6 rounded shadow w-80" aria-labelledby="login-title">
-    <h1 id="login-title" class="text-xl font-bold mb-4 text-center">Login</h1>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 flex items-center justify-center h-screen">
+  <main class="bg-white dark:bg-gray-800 p-6 rounded shadow w-80" aria-labelledby="login-title">
+    <h1 id="login-title" class="text-xl font-bold mb-4 text-center">Login
+      <span class="ml-2 text-xs font-semibold bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 px-2 py-1 rounded">Beta</span>
+    </h1>
     <label for="email" class="sr-only">Email</label>
-    <input id="email" class="border p-2 w-full mb-2" type="email" placeholder="Email" />
+    <input id="email" class="border p-2 w-full mb-2 dark:bg-gray-700 dark:border-gray-600 dark:text-white" type="email" placeholder="Email" />
     <label for="password" class="sr-only">Password</label>
-    <input id="password" class="border p-2 w-full mb-2" type="password" placeholder="Password" />
-    <label for="remember" class="flex items-center mb-4 text-sm">
+    <input id="password" class="border p-2 w-full mb-2 dark:bg-gray-700 dark:border-gray-600 dark:text-white" type="password" placeholder="Password" />
+    <label for="remember" class="flex items-center mb-4 text-sm text-gray-700 dark:text-gray-300">
       <input id="remember" type="checkbox" class="mr-2" /> Remember me
     </label>
-    <button id="login" class="bg-blue-600 text-white px-4 py-2 w-full rounded" aria-label="Log in with email and password">Login</button>
-    <button id="google-login" class="bg-red-600 text-white px-4 py-2 w-full rounded mt-2" aria-label="Log in with Google">Login with Google</button>
-    <p id="message" class="text-red-500 mt-2 text-center" aria-live="polite"></p>
+    <button id="login" class="bg-blue-600 text-white px-4 py-2 w-full rounded dark:bg-blue-500" aria-label="Log in with email and password">Login</button>
+    <button id="google-login" class="bg-red-600 text-white px-4 py-2 w-full rounded mt-2 dark:bg-red-500" aria-label="Log in with Google">Login with Google</button>
+    <p id="message" class="text-red-500 dark:text-red-400 mt-2 text-center" aria-live="polite"></p>
     <p class="text-center text-sm mt-2">
-      <a href="#" id="forgot" class="text-blue-500 underline">Forgot password?</a>
+      <a href="#" id="forgot" class="text-blue-500 dark:text-blue-400 underline">Forgot password?</a>
     </p>
     <p class="text-center text-sm mt-2">
       Don't have an account?
-      <a href="#" id="show-signup" class="text-blue-500 underline">Sign up</a>
+      <a href="#" id="show-signup" class="text-blue-500 dark:text-blue-400 underline">Sign up</a>
     </p>
   </main>
 
@@ -39,34 +46,34 @@
     aria-modal="true"
     aria-labelledby="signup-title"
   >
-    <div class="bg-white p-6 rounded shadow w-80">
-      <h1 id="signup-title" class="text-xl font-bold mb-4 text-center">Sign Up</h1>
+    <div class="bg-white dark:bg-gray-800 p-6 rounded shadow w-80">
+      <h1 id="signup-title" class="text-xl font-bold mb-4 text-center dark:text-gray-100">Sign Up</h1>
       <label for="signup-email" class="sr-only">Email</label>
       <input
         id="signup-email"
-        class="border p-2 w-full mb-2"
+        class="border p-2 w-full mb-2 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
         type="email"
         placeholder="Email"
       />
       <label for="signup-password" class="sr-only">Password</label>
       <input
         id="signup-password"
-        class="border p-2 w-full mb-2"
+        class="border p-2 w-full mb-2 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
         type="password"
         placeholder="Password"
       />
       <label for="signup-confirm" class="sr-only">Confirm Password</label>
       <input
         id="signup-confirm"
-        class="border p-2 w-full mb-2"
+        class="border p-2 w-full mb-2 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
         type="password"
         placeholder="Confirm Password"
       />
-      <button id="signup-btn" class="bg-blue-600 text-white px-4 py-2 w-full rounded" aria-label="Create account">
+      <button id="signup-btn" class="bg-blue-600 text-white px-4 py-2 w-full rounded dark:bg-blue-500" aria-label="Create account">
         Sign Up
       </button>
-      <p id="signup-message" class="text-red-500 mt-2 text-center" aria-live="polite"></p>
-      <button id="signup-close" class="text-sm text-blue-500 underline mt-2 w-full" aria-label="Close sign up form">
+      <p id="signup-message" class="text-red-500 dark:text-red-400 mt-2 text-center" aria-live="polite"></p>
+      <button id="signup-close" class="text-sm text-blue-500 dark:text-blue-400 underline mt-2 w-full" aria-label="Close sign up form">
         Cancel
       </button>
     </div>
@@ -80,20 +87,20 @@
     aria-modal="true"
     aria-labelledby="reset-title"
   >
-    <div class="bg-white p-6 rounded shadow w-80">
-      <h1 id="reset-title" class="text-xl font-bold mb-4 text-center">Reset Password</h1>
+    <div class="bg-white dark:bg-gray-800 p-6 rounded shadow w-80">
+      <h1 id="reset-title" class="text-xl font-bold mb-4 text-center dark:text-gray-100">Reset Password</h1>
       <label for="reset-email" class="sr-only">Email</label>
       <input
         id="reset-email"
-        class="border p-2 w-full mb-2"
+        class="border p-2 w-full mb-2 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
         type="email"
         placeholder="Email"
       />
-      <button id="reset-btn" class="bg-blue-600 text-white px-4 py-2 w-full rounded" aria-label="Send password reset email">
+      <button id="reset-btn" class="bg-blue-600 text-white px-4 py-2 w-full rounded dark:bg-blue-500" aria-label="Send password reset email">
         Send reset email
       </button>
-      <p id="reset-message" class="text-red-500 mt-2 text-center" aria-live="polite"></p>
-      <button id="reset-close" class="text-sm text-blue-500 underline mt-2 w-full" aria-label="Close reset password form">
+      <p id="reset-message" class="text-red-500 dark:text-red-400 mt-2 text-center" aria-live="polite"></p>
+      <button id="reset-close" class="text-sm text-blue-500 dark:text-blue-400 underline mt-2 w-full" aria-label="Close reset password form">
         Cancel
       </button>
     </div>

--- a/docs/marketing-site/index.html
+++ b/docs/marketing-site/index.html
@@ -3,6 +3,7 @@ Plan:
 1. Replace placeholder feature descriptions with actual copy.
 2. Summarize workflow in the How It Works section.
 3. Clarify that the project is free in the Pricing section.
+4. Add dark mode classes for accessibility.
 -->
 <!DOCTYPE html>
 <html lang="en">
@@ -16,28 +17,30 @@ Plan:
     <link rel="stylesheet" href="styles.css">
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <header class="top-nav">
-        <a href="#" class="logo">GPT Fusion</a>
+<body class="bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+    <header class="top-nav bg-neutral-light dark:bg-gray-800">
+        <a href="#" class="logo text-gray-900 dark:text-gray-100">GPT Fusion</a>
         <nav id="nav" class="nav" aria-label="Main navigation">
             <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
                 <span class="nav-toggle__icon" aria-hidden="true"></span>
             </button>
             <ul id="nav-menu" class="nav-menu">
-                <li><a href="#features">Features</a></li>
-                <li><a href="#how">How It Works</a></li>
-                <li><a href="#pricing">Pricing</a></li>
-                <li><a href="#contact" class="btn btn--primary">Get Started</a></li>
+                <li><a href="#features" class="text-gray-900 dark:text-gray-100">Features</a></li>
+                <li><a href="#how" class="text-gray-900 dark:text-gray-100">How It Works</a></li>
+                <li><a href="#pricing" class="text-gray-900 dark:text-gray-100">Pricing</a></li>
+                <li><a href="#contact" class="btn btn--primary dark:bg-blue-500">Get Started</a></li>
             </ul>
         </nav>
     </header>
     <main>
-        <section class="hero text-center py-16">
-            <h1 class="text-4xl font-bold mb-4">GPT Fusion</h1>
+        <section class="hero text-center py-16 bg-neutral-light dark:bg-gray-800">
+            <h1 class="text-4xl font-bold mb-4">GPT Fusion
+                <span class="ml-2 align-middle text-xs font-semibold bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 px-2 py-1 rounded">Open Source</span>
+            </h1>
             <p class="text-xl mb-6">Build, test and remix AI-powered mini-apps in minutes</p>
-            <a href="https://github.com/costasford/gpt-fusion" class="btn btn--primary">Get Started on GitHub</a>
+            <a href="https://github.com/costasford/gpt-fusion" class="btn btn--primary dark:bg-blue-500">Get Started on GitHub</a>
         </section>
-        <section id="features" class="features">
+        <section id="features" class="features bg-neutral-light dark:bg-gray-800">
             <h2>Features</h2>
             <div class="grid">
                 <div class="feature-item">
@@ -62,20 +65,20 @@ Plan:
             <h2>How It Works</h2>
             <p>Clone the repository, install the dependencies and run the tests. Combine the Python package, front-end kit and Unity demo to build your own AI-enabled apps.</p>
         </section>
-        <section id="pricing" class="pricing">
+        <section id="pricing" class="pricing bg-neutral-light dark:bg-gray-800">
             <h2>Pricing</h2>
             <p>GPT Fusion is completely free and MIT-licensed. Use the code as-is or adapt it for your projects.</p>
         </section>
-        <section id="contact" class="contact">
+        <section id="contact" class="contact bg-neutral-light dark:bg-gray-800">
             <h2>Contact Us</h2>
             <form action="#" method="post" class="contact-form">
                 <label for="email">Email</label>
                 <input type="email" id="email" name="email" required>
-                <button type="submit" class="btn btn--primary">Submit</button>
+                <button type="submit" class="btn btn--primary dark:bg-blue-500">Submit</button>
             </form>
         </section>
     </main>
-    <footer class="footer">
+    <footer class="footer bg-neutral-light dark:bg-gray-800">
         <div class="footer-links">
             <a href="#">Privacy Policy</a>
             <a href="#">Terms of Service</a>


### PR DESCRIPTION
### Why
Improve UI accessibility in the demo sites.

### How
- apply Tailwind `dark:` classes to login form and marketing site
- add high contrast badges for "Beta" and "Open Source"

### Tests
See run below (fails due to missing `jekyll-sitemap`):
```
$ python scripts/run_checks.py
...cannot load such file -- jekyll-sitemap...
```

### Screenshots / GIFs
N/A

### Checklist
- [ ] I ran `scripts/run_checks.py`
- [ ] I updated docs where needed
- [ ] I asked for review from @costasford

------
https://chatgpt.com/codex/tasks/task_e_68758e414dd083218c3399b020cf0bf6