### PR TITLE
[Feat] Improve docs landing page

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,6 +1,8 @@
+# Plan: add jekyll-minifier to compress final site assets
 source "https://rubygems.org"
 
 gem "jekyll", "~> 4.2"
 gem "jekyll-seo-tag"
 gem "jekyll-sitemap"
 gem "jekyll-theme-cayman"
+gem "jekyll-minifier"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,7 @@
 # Plan:
 # 1. Keep existing Jekyll config.
 # 2. Add DocSearch placeholders for Algolia integration.
+# 3. Enable jekyll-minifier for smaller builds.
 theme: jekyll-theme-cayman
 title: GPT Fusion
 description: Practical demos of human-AI collaboration
@@ -9,6 +10,7 @@ baseurl: "/gpt-fusion"
 plugins:
   - jekyll-seo-tag
   - jekyll-sitemap
+  - jekyll-minifier
 github:
   is_project_page: false
 # DocSearch credentials are placeholders

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,12 +16,15 @@ Plan:
 
 <div class="hero container">
   <h1>GPT Fusion Playground</h1>
-  <p><strong>Practical demos of human-AI collaboration</strong></p>
+  <p class="text-xl font-semibold">Build, test & remix AI mini-apps in minutes</p>
   <p>
     <a href="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml"><img src="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg" alt="CI Status" loading="lazy"></a>
     <a href="https://codecov.io/gh/costasford/gpt-fusion"><img src="https://app.codecov.io/gh/costasford/gpt-fusion/branch/main/graph/badge.svg" alt="Coverage Status" loading="lazy"></a>
     <a href="https://pypi.org/project/gpt-fusion/"><img src="https://img.shields.io/pypi/dm/gpt-fusion.svg" alt="PyPI Downloads" loading="lazy"></a>
     <a href="https://github.com/costasford/gpt-fusion/blob/main/LICENSE"><img src="https://img.shields.io/github/license/costasford/gpt-fusion" alt="License" loading="lazy"></a>
+  </p>
+  <p>
+    <a href="https://github.com/costasford/gpt-fusion" class="btn">Get Started on GitHub</a>
   </p>
   <p>Use the search bar to jump directly to any topic in the docs.</p>
 </div>


### PR DESCRIPTION
### Why
Add a clearer call to action and minify the generated site.

### How
- hero section now includes tagline and GitHub button
- enable `jekyll-minifier` via Gemfile and config

### Tests
```
40 passed, 1 warning in 0.72s
```

### Screenshots / GIFs
N/A

### Checklist
- [x] I ran `scripts/run_checks.py`
- [ ] I updated docs where needed
- [ ] I asked for review from @costasford

------
https://chatgpt.com/codex/tasks/task_e_6875926ca33c832191986b377e5fe820