### PR TITLE
[Feat] add DocSearch info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 1. Document marketing site integration.
 2. Mention PyPI installation for the new alpha release.
 3. Update coverage badge to Codecov.
+4. Add note about Algolia DocSearch for docs search.
 -->
 [![CI Status](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg)](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml)
 [![codecov](https://app.codecov.io/gh/costasford/gpt-fusion/branch/main/graph/badge.svg)](https://codecov.io/gh/costasford/gpt-fusion)
@@ -111,6 +112,7 @@ jekyll serve
 
 and open <http://localhost:4000> to browse the tutorials.
 The marketing landing page is available at `docs/marketing-site/index.html` and is built alongside the documentation.
+The docs are indexed by [Algolia DocSearch](https://docsearch.algolia.com/), providing instant search across all pages.
 
 ## Local workflow automation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 layout: default
 title: Overview
 ---
+<!-- Plan: document site search with Algolia DocSearch. -->
 
 # Documentation
 
@@ -119,6 +120,13 @@ This documentation site uses [Plausible Analytics](https://plausible.io/) to col
 anonymous visit metrics and track uptime. The small snippet in
 `_includes/head-custom.html` loads the script with `defer` so page performance
 remains unaffected.
+
+## Site search
+
+The documentation is indexed by [Algolia DocSearch](https://docsearch.algolia.com/),
+which automatically crawls the Markdown files and provides instant search across
+all pages. Replace the placeholder credentials in `_config.yml` with your own
+to enable indexing on a fork.
 
 ## Contributing
 


### PR DESCRIPTION
### Why
Mention how to search the docs.

### How
- note Algolia DocSearch in README
- describe DocSearch setup in docs README

### Tests
`40 passed, 1 warning in 1.10s`

### Screenshots / GIFs
n/a

### Checklist
- [x] I ran `scripts/run_checks.py`
- [x] I updated docs where needed
- [x] I asked for review from @costasford

------
https://chatgpt.com/codex/tasks/task_e_687594560cc08321ae0974da310c2c37