### PR TITLE
[Feat] clarify badge alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 3. Update coverage badge to Codecov.
 4. Add note about Algolia DocSearch for docs search.
 -->
-[![CI Status](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg)](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml)
-[![codecov](https://app.codecov.io/gh/costasford/gpt-fusion/branch/main/graph/badge.svg)](https://codecov.io/gh/costasford/gpt-fusion)
-[![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
-[![License](https://img.shields.io/github/license/costasford/gpt-fusion)](LICENSE)
-[![PyPI](https://img.shields.io/pypi/v/gpt-fusion.svg)](https://pypi.org/project/gpt-fusion/)
+[![CI](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg)](https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/costasford/gpt-fusion/branch/main/graph/badge.svg)](https://codecov.io/gh/costasford/gpt-fusion)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
+[![MIT License](https://img.shields.io/github/license/costasford/gpt-fusion)](LICENSE)
+[![PyPI Version](https://img.shields.io/pypi/v/gpt-fusion.svg)](https://pypi.org/project/gpt-fusion/)
 [![Downloads](https://img.shields.io/pypi/dm/gpt-fusion.svg)](https://pypi.org/project/gpt-fusion/)
 
 "Practical demos of human-AI collaboration"

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,8 @@ Plan:
   <h1>GPT Fusion Playground</h1>
   <p class="text-xl font-semibold">Build, test & remix AI mini-apps in minutes</p>
   <p>
-    <a href="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml"><img src="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg" alt="CI Status" loading="lazy"></a>
-    <a href="https://codecov.io/gh/costasford/gpt-fusion"><img src="https://app.codecov.io/gh/costasford/gpt-fusion/branch/main/graph/badge.svg" alt="Coverage Status" loading="lazy"></a>
+    <a href="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml"><img src="https://github.com/costasford/gpt-fusion/actions/workflows/ci.yml/badge.svg" alt="CI" loading="lazy"></a>
+    <a href="https://codecov.io/gh/costasford/gpt-fusion"><img src="https://codecov.io/gh/costasford/gpt-fusion/branch/main/graph/badge.svg" alt="Coverage" loading="lazy"></a>
     <a href="https://pypi.org/project/gpt-fusion/"><img src="https://img.shields.io/pypi/dm/gpt-fusion.svg" alt="PyPI Downloads" loading="lazy"></a>
     <a href="https://github.com/costasford/gpt-fusion/blob/main/LICENSE"><img src="https://img.shields.io/github/license/costasford/gpt-fusion" alt="License" loading="lazy"></a>
   </p>


### PR DESCRIPTION
### Why
Improve accessibility of docs badges after coverage link fix.

### How
- add descriptive alt text for CI and coverage badges in README and docs index
- unify domain usage for Codecov badge

### Tests
```
40 passed, 1 warning in 0.80s
```

### Screenshots / GIFs
n/a

### Checklist
- [x] I ran `scripts/run_checks.py`
- [x] I updated docs where needed
- [ ] I asked for review from @costasford

------
https://chatgpt.com/codex/tasks/task_e_68759b7e8204832194b27d9c551e1ac0