### PR TITLE
[Feat] document Render API demo

### DIFF
--- a/docs/api-playground.md
+++ b/docs/api-playground.md
@@ -30,8 +30,8 @@ Open <http://localhost:8000/redoc> to explore the auto-generated ReDoc docs and 
 
 1. Create a new **Web Service** from your GitHub repo.
 2. Set the build command to `pip install "gpt-fusion[backend]"`.
-3. Use `uvicorn gpt_fusion.backend:app --host 0.0.0.0 --port $PORT` as the start command.
-4. After the service spins up, visit `<service-url>/redoc` to try the API in your browser.
+3. Use `uvicorn gpt_fusion.backend:app --host 0.0.0.0 --port $PORT --root-path /api` as the start command so all routes live under `/api`.
+4. After the service spins up, visit `<service-url>/api/redoc` to try the API in your browser or `curl <service-url>/api/greet/Fusion` for a quick test.
 
 ## Deploying to Heroku
 

--- a/docs/assets/js/bundle.js
+++ b/docs/assets/js/bundle.js
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
   button.addEventListener('click', async () => {
     const input = document.getElementById('name-input');
     const name = input ? input.value.trim() || 'Fusion' : 'Fusion';
-    const apiBase = window.API_BASE || 'https://gpt-fusion-demo.fly.dev';
+    const apiBase = window.API_BASE || '/api';
     try {
       const res = await fetch(`${apiBase}/greet/${encodeURIComponent(name)}`);
       if (!res.ok) throw new Error('Request failed');

--- a/docs/assets/js/playground.js
+++ b/docs/assets/js/playground.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   button.addEventListener('click', async () => {
     const input = document.getElementById('name-input');
     const name = input ? input.value.trim() || 'Fusion' : 'Fusion';
-    const apiBase = window.API_BASE || 'https://gpt-fusion-demo.fly.dev';
+    const apiBase = window.API_BASE || '/api';
     try {
       const res = await fetch(`${apiBase}/greet/${encodeURIComponent(name)}`);
       if (!res.ok) throw new Error('Request failed');

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,16 @@ Plan:
 </section>
 
 <section class="container">
+  <h2>Try the API</h2>
+  <div id="playground">
+    <input id="name-input" type="text" value="Fusion" aria-label="Name">
+    <button id="greet-btn">Greet</button>
+    <pre id="greet-output"></pre>
+  </div>
+  <p>The demo assumes a backend running at <code>/api</code> on Render.</p>
+</section>
+
+<section class="container">
   <h2>Projects</h2>
   <p>More information about each demo lives on the <a href="projects.md">Projects page</a>.</p>
   <div class="projects-grid">

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -68,7 +68,7 @@ StreamerABC playing Just Chatting with 15000 viewers
 ```
 ## API Playground
 
-Host the FastAPI demo on Render or Heroku and open `/redoc` to experiment with the endpoints. See [api-playground.md](api-playground.md) for setup steps.
+Host the FastAPI demo on Render or Heroku and open `/api/redoc` to experiment with the endpoints. See [api-playground.md](api-playground.md) for setup steps.
 
 
 ## Tutorial

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,8 @@
+services:
+  - type: web
+    name: gpt-fusion-api
+    env: python
+    plan: free
+    buildCommand: pip install "gpt-fusion[backend]"
+    startCommand: uvicorn gpt_fusion.backend:app --host 0.0.0.0 --port $PORT --root-path /api
+    healthCheckPath: /api/


### PR DESCRIPTION
### Why
Allow users to try the FastAPI backend before cloning.

### How
- added render.yaml config for a free dyno
- updated API docs for `/api` base path
- bundled JS now points to `/api`
- new "Try the API" section on the homepage

### Tests
`40 passed, 1 warning in 0.72s`

### Screenshots / GIFs
N/A

### Checklist
- [x] I ran `scripts/run_checks.py`
- [x] I updated docs where needed
- [ ] I asked for review from @costasford

------
https://chatgpt.com/codex/tasks/task_e_68759e89983083219e482b32ad290520